### PR TITLE
Added structured errors (with pointers) to Conformity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.pyc
 __pycache__
 
+*.swp

--- a/conformity/error.py
+++ b/conformity/error.py
@@ -1,0 +1,17 @@
+class Error(object):
+    def __init__(self, message, pointer=None):
+        self.message = message
+        self.pointer = pointer
+
+    def __eq__(self, other):
+        if not isinstance(other, Error):
+            raise NotImplemented()
+        return self.message == other.message and self.pointer == other.pointer
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __repr__(self):
+        if self.pointer:
+            return 'Error("{}", pointer="{}")'.format(self.message, self.pointer)
+        return 'Error("{}")'.format(self.message)

--- a/conformity/fields/basic.py
+++ b/conformity/fields/basic.py
@@ -1,6 +1,8 @@
 from __future__ import unicode_literals
 import six
 
+from ..error import Error
+
 
 class Base(object):
     """
@@ -12,7 +14,9 @@ class Base(object):
         Returns a list of errors with the value. An empty/None return means
         that it's valid.
         """
-        return ["Validation not implemented on base type"]
+        return [
+            Error("Validation not implemented on base type"),
+        ]
 
 
 class Constant(Base):
@@ -29,7 +33,9 @@ class Constant(Base):
         that it's valid.
         """
         if value != self.value:
-            return ["Value is not %r" % self.value]
+            return [
+                Error("Value is not %r" % self.value),
+            ]
 
 
 class Anything(Base):
@@ -49,7 +55,9 @@ class Hashable(Anything):
         try:
             hash(value)
         except TypeError:
-            return ["Value is not hashable"]
+            return [
+                Error("Value is not hashable"),
+            ]
 
 
 class Boolean(Base):
@@ -59,7 +67,9 @@ class Boolean(Base):
 
     def errors(self, value):
         if not isinstance(value, bool):
-            return ["Not a boolean"]
+            return [
+                Error("Not a boolean"),
+            ]
 
 
 class Integer(Base):
@@ -78,15 +88,25 @@ class Integer(Base):
 
     def errors(self, value):
         if not isinstance(value, self.valid_type):
-            return ["Not a %s" % self.valid_noun]
+            return [
+                Error("Not a %s" % self.valid_noun),
+            ]
         elif self.gt is not None and value <= self.gt:
-            return ["Value not > %s" % self.gt]
+            return [
+                Error("Value not > %s" % self.gt),
+            ]
         elif self.lt is not None and value >= self.lt:
-            return ["Value not < %s" % self.lt]
+            return [
+                Error("Value not < %s" % self.lt),
+            ]
         elif self.gte is not None and value < self.gte:
-            return ["Value not >= %s" % self.gte]
+            return [
+                Error("Value not >= %s" % self.gte),
+            ]
         elif self.lte is not None and value > self.lte:
-            return ["Value not <= %s" % self.lte]
+            return [
+                Error("Value not <= %s" % self.lte),
+            ]
 
 
 class Float(Integer):
@@ -111,9 +131,13 @@ class UnicodeString(Base):
 
     def errors(self, value):
         if not isinstance(value, self.valid_type):
-            return ["Not a %s" % self.valid_noun]
+            return [
+                Error("Not a %s" % self.valid_noun),
+            ]
         elif self.max_length is not None and len(value) > self.max_length:
-            return ["String longer than %s" % self.max_length]
+            return [
+                Error("String longer than %s" % self.max_length),
+            ]
 
 
 class ByteString(UnicodeString):

--- a/conformity/fields/meta.py
+++ b/conformity/fields/meta.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 from .basic import Base
+from ..error import Error
 
 
 class Polymorph(Base):
@@ -24,7 +25,9 @@ class Polymorph(Base):
             if "__default__" in self.contents_map:
                 switch_value = "__default__"
             else:
-                return ["Invalid switch value %r" % switch_value]
+                return [
+                    Error("Invalid switch value %r" % switch_value),
+                ]
         field = self.contents_map[switch_value]
         # Run field errors
         return field.errors(value)
@@ -39,6 +42,8 @@ class ObjectInstance(Base):
 
     def errors(self, value):
         if not isinstance(value, self.valid_type):
-            return ["not an instance of %s" % self.valid_type.__name__]
+            return [
+                Error("Not an instance of %s" % self.valid_type.__name__),
+            ]
         else:
             return []

--- a/conformity/fields/temporal.py
+++ b/conformity/fields/temporal.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 import datetime
 
 from .basic import Base
+from ..error import Error
 
 
 class TemporalBase(Base):
@@ -14,15 +15,25 @@ class TemporalBase(Base):
     def errors(self, value):
         if not type(value) == self.valid_type:
             # using stricter type checking, because date is subclass of datetime, but they're not comparable
-            return ["Not a %s instance" % self.valid_noun]
+            return [
+                Error("Not a %s instance" % self.valid_noun),
+            ]
         elif self.gt is not None and value <= self.gt:
-            return ["Value not > %s" % self.gt]
+            return [
+                Error("Value not > %s" % self.gt),
+            ]
         elif self.lt is not None and value >= self.lt:
-            return ["Value not < %s" % self.lt]
+            return [
+                Error("Value not < %s" % self.lt),
+            ]
         elif self.gte is not None and value < self.gte:
-            return ["Value not >= %s" % self.gte]
+            return [
+                Error("Value not >= %s" % self.gte),
+            ]
         elif self.lte is not None and value > self.lte:
-            return ["Value not <= %s" % self.lte]
+            return [
+                Error("Value not <= %s" % self.lte),
+            ]
 
 
 class DateTime(TemporalBase):

--- a/conformity/validator.py
+++ b/conformity/validator.py
@@ -23,7 +23,13 @@ def validate(schema, value, noun="value"):
     """
     errors = schema.errors(value)
     if errors:
-        raise ValidationError("Invalid %s:\n  - %s" % (noun, "\n  - ".join(errors)))
+        error_details = ''
+        for error in errors:
+            if error.pointer:
+                error_details += '  - %s: %s\n' % (error.pointer, error.message)
+            else:
+                error_details += '  - %s\n' % error.message
+        raise ValidationError("Invalid %s:\n%s" % (noun, error_details))
 
 
 def validate_call(kwargs, returns, is_method=False):

--- a/setup.py
+++ b/setup.py
@@ -9,4 +9,5 @@ setup(
     install_requires=[
         'six',
     ],
+    test_suite='conformity.tests',
 )


### PR DESCRIPTION
Errors are now returned as Error() object instances. They contain the original error message as well as a pointer to the key or index that originated the error (for container types).