### PR TITLE
Added custom field validation support via the validators attribute.

### DIFF
--- a/conformity/fields/meta.py
+++ b/conformity/fields/meta.py
@@ -16,8 +16,9 @@ class Polymorph(Base):
     switch_field = attr.ib()
     contents_map = attr.ib()
     description = attr.ib(default=None)
+    validators = attr.ib(default=attr.Factory(list))
 
-    def errors(self, value):
+    def validate(self, value):
         # Get switch field value
         bits = self.switch_field.split(".")
         switch_value = value
@@ -55,8 +56,9 @@ class ObjectInstance(Base):
 
     valid_type = attr.ib()
     description = attr.ib(default=None)
+    validators = attr.ib(default=attr.Factory(list))
 
-    def errors(self, value):
+    def validate(self, value):
         if not isinstance(value, self.valid_type):
             return [
                 Error("Not an instance of %s" % self.valid_type.__name__),

--- a/conformity/fields/structures.py
+++ b/conformity/fields/structures.py
@@ -29,8 +29,9 @@ class List(Base):
     max_length = attr.ib(default=None)
     min_length = attr.ib(default=None)
     description = attr.ib(default=None)
+    validators = attr.ib(default=attr.Factory(list))
 
-    def errors(self, value):
+    def validate(self, value):
         if not isinstance(value, list):
             return [
                 Error("Not a list"),
@@ -71,8 +72,9 @@ class Dictionary(Base):
     optional_keys = attr.ib(default=attr.Factory(list))
     allow_extra_keys = attr.ib(default=False)
     description = attr.ib(default=None)
+    validators = attr.ib(default=attr.Factory(list))
 
-    def errors(self, value):
+    def validate(self, value):
         if not isinstance(value, dict):
             return [
                 Error("Not a dict"),
@@ -121,8 +123,9 @@ class SchemalessDictionary(Base):
     key_type = attr.ib(default=attr.Factory(Hashable))
     value_type = attr.ib(default=attr.Factory(Anything))
     description = attr.ib(default=None)
+    validators = attr.ib(default=attr.Factory(list))
 
-    def errors(self, value):
+    def validate(self, value):
         if not isinstance(value, dict):
             return [
                 Error("Not a dict"),
@@ -159,13 +162,15 @@ class Tuple(Base):
 
     def __init__(self, *contents, **kwargs):
         # We can't use attrs here because we need to capture all positional
-        # arguments, but also extract the description kwarg if provided.
+        # arguments, but also extract the description and validators kwargs if
+        # provided.
         self.contents = contents
         self.description = kwargs.get("description", None)
+        self.validators = kwargs.get("validators", [])
         if list(kwargs.keys()) not in ([], ["description"]):
             raise ValueError("Unknown keyword arguments %s" % kwargs.keys())
 
-    def errors(self, value):
+    def validate(self, value):
         if not isinstance(value, tuple):
             return [
                 Error("Not a tuple"),

--- a/conformity/fields/temporal.py
+++ b/conformity/fields/temporal.py
@@ -18,6 +18,7 @@ class TemporalBase(Base):
     lt = attr.ib(default=None)
     lte = attr.ib(default=None)
     description = attr.ib(default=None)
+    validators = attr.ib(default=attr.Factory(list))
 
     def __init__(self, gt=None, lt=None, gte=None, lte=None):
         self.gt = gt
@@ -25,7 +26,7 @@ class TemporalBase(Base):
         self.gte = gte
         self.lte = lte
 
-    def errors(self, value):
+    def validate(self, value):
         if not type(value) == self.valid_type:
             # using stricter type checking, because date is subclass of datetime, but they're not comparable
             return [

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,11 @@
 from setuptools import setup, find_packages
 from conformity import __version__
 
+
+tests_require = [
+    'mock',
+]
+
 setup(
     name='conformity',
     version=__version__,
@@ -18,7 +23,11 @@ setup(
         'six',
         'attrs>=16',
     ],
+    tests_require=tests_require,
     test_suite='conformity.tests',
+    extras_require={
+        'testing': tests_require,
+    },
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
- Moved `errors()` to `validate()` for all Fields.
- Added `validators` attribute to all Fields. `validators` is a list of callables that take a value and return a (potentially empty) list of `Error` instances.
- `errors()` now calls `validate()`. If no errors are returned from `validate()`, all `validators` are called with the `value` passed to `errors()`. `errors()` then returns a (potentially empty) list of errors returned by the `validators`.