### PR TITLE
Add IP Address fields (and fix Any to not use pointers)

### DIFF
--- a/conformity/fields/__init__.py
+++ b/conformity/fields/__init__.py
@@ -3,3 +3,4 @@ from .structures import List, Dictionary, SchemalessDictionary, Tuple
 from .meta import Polymorph, ObjectInstance, Any
 from .temporal import DateTime, Date, TimeDelta, Time, TZInfo
 from .geo import Latitude, Longitude
+from .net import IPAddress, IPv4Address, IPv6Address

--- a/conformity/fields/geo.py
+++ b/conformity/fields/geo.py
@@ -1,9 +1,6 @@
 from __future__ import unicode_literals
 import attr
-import six
 
-from ..error import Error
-from ..utils import strip_none
 from .basic import Float
 
 

--- a/conformity/fields/meta.py
+++ b/conformity/fields/meta.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 import attr
 
 from .basic import Base
-from .structures import _update_error_pointer
 from ..error import Error
 from ..utils import strip_none
 
@@ -100,10 +99,7 @@ class Any(Base):
             if not sub_errors:
                 return []
             # Otherwise, add the errors to the overall results
-            result.extend(
-                _update_error_pointer(error, i)
-                for error in sub_errors
-            )
+            result.extend(sub_errors)
         return result
 
     def introspect(self):

--- a/conformity/fields/net.py
+++ b/conformity/fields/net.py
@@ -1,0 +1,125 @@
+from __future__ import unicode_literals
+import attr
+import functools
+import re
+import six
+
+from ..error import Error
+from ..utils import strip_none
+from .basic import UnicodeString
+from .meta import Any
+
+
+ipv4_regex = re.compile(r'^(25[0-5]|2[0-4]\d|[0-1]?\d?\d)(\.(25[0-5]|2[0-4]\d|[0-1]?\d?\d)){3}$')
+
+
+@attr.s
+class IPv4Address(UnicodeString):
+
+    def errors(self, value):
+        # Get any basic type errors
+        result = super(IPv4Address, self).errors(value)
+        if result:
+            return result
+        # Check for IPv4-ness
+        if ipv4_regex.match(value):
+            return []
+        else:
+            return [Error("Not a valid IPv4 address")]
+
+    def introspect(self):
+        return strip_none({
+            "type": "ipv4_address",
+            "description": self.description,
+        })
+
+
+@attr.s
+class IPv6Address(UnicodeString):
+
+    def errors(self, value):
+        # Get any basic type errors
+        result = super(IPv6Address, self).errors(value)
+        if result:
+            return result
+        # It must have at least one :
+        if ':' not in value:
+            return [Error("Not a valid IPv6 address (no colons)")]
+        # We can only have one '::' shortener.
+        if value.count('::') > 1:
+            return [Error("Not a valid IPv6 address (multiple shorteners)")]
+        # '::' should be encompassed by start, digits or end.
+        if ':::' in value:
+            return [Error("Not a valid IPv6 address (shortener not bounded)")]
+        # A single colon can neither start nor end an address.
+        if ((value.startswith(':') and not value.startswith('::')) or
+                (value.endswith(':') and not value.endswith('::'))):
+            return [Error("Not a valid IPv6 address (colon at start or end)")]
+        # We can never have more than 7 ':' (1::2:3:4:5:6:7:8 is invalid)
+        if value.count(':') > 7:
+            return [Error("Not a valid IPv6 address (too many colons)")]
+        # If we have no concatenation, we need to have 8 fields with 7 ':'.
+        if '::' not in value and value.count(':') != 7:
+            # We might have an IPv4 mapped address.
+            if value.count('.') != 3:
+                return [Error("Not a valid IPv6 address (v4 section not valid address)")]
+        value = self.expand_ipv6_address(value)
+        # Check that each of the hextets are between 0x0 and 0xFFFF.
+        for hextet in value.split(':'):
+            if hextet.count('.') == 3:
+                # If we have an IPv4 mapped address, the IPv4 portion has to
+                # be at the end of the IPv6 portion.
+                if not value.split(':')[-1] == hextet:
+                    return [Error("Not a valid IPv6 address (v4 section not at end)")]
+                if not ipv4_regex.match(hextet):
+                    return [Error("Not a valid IPv6 address (v4 section not valid address)")]
+            else:
+                try:
+                    # a value error here means that we got a bad hextet,
+                    # something like 0xzzzz
+                    if int(hextet, 16) < 0x0 or int(hextet, 16) > 0xFFFF:
+                        return [Error("Not a valid IPv6 address (invalid hextet)")]
+                except ValueError:
+                    return [Error("Not a valid IPv6 address (invalid hextet)")]
+        return []
+
+    def expand_ipv6_address(self, value):
+        """
+        Expands a potentially-shortened IPv6 address into its full length
+        """
+        new_ip = []
+        hextet = value.split('::')
+        # If there is a ::, we need to expand it with zeroes
+        # to get to 8 hextets - unless there is a dot in the last hextet,
+        # meaning we're doing v4-mapping
+        if '.' in value.split(':')[-1]:
+            fill_to = 7
+        else:
+            fill_to = 8
+        if len(hextet) > 1:
+            sep = len(hextet[0].split(':')) + len(hextet[1].split(':'))
+            new_ip = hextet[0].split(':')
+            for _ in six.moves.range(fill_to - sep):
+                new_ip.append('0000')
+            new_ip += hextet[1].split(':')
+        else:
+            new_ip = value.split(':')
+        # Now need to make sure every hextet is 4 lower case characters.
+        # If a hextet is < 4 characters, we've got missing leading 0's.
+        ret_ip = []
+        for hextet in new_ip:
+            ret_ip.append(('0' * (4 - len(hextet)) + hextet).lower())
+        return ':'.join(ret_ip)
+
+    def introspect(self):
+        return strip_none({
+            "type": "ipv6_address",
+            "description": self.description,
+        })
+
+
+IPAddress = functools.partial(
+    Any,
+    IPv4Address(),
+    IPv6Address(),
+)

--- a/conformity/tests/test_fields.py
+++ b/conformity/tests/test_fields.py
@@ -386,8 +386,8 @@ class FieldTests(unittest.TestCase):
             [],
         )
         self.assertEqual(
-            schema.errors("three"),
-            [Error("Value is not u'one'", pointer="0"), Error("Value is not u'two'", pointer="1")],
+            len(schema.errors("three")),
+            2,
         )
 
     def test_latitude(self):

--- a/conformity/tests/test_fields_net.py
+++ b/conformity/tests/test_fields_net.py
@@ -1,0 +1,98 @@
+from __future__ import unicode_literals
+
+import unittest
+
+from ..fields import (
+    IPAddress,
+    IPv4Address,
+    IPv6Address,
+)
+from ..error import Error
+
+
+class NetFieldTests(unittest.TestCase):
+    """
+    Tests net fields
+    """
+
+    def test_ipv4address(self):
+        schema = IPv4Address()
+        self.assertEqual(
+            schema.errors("127.0.0.1"),
+            [],
+        )
+        self.assertEqual(
+            schema.errors("127.300.0.1"),
+            [Error("Not a valid IPv4 address")],
+        )
+        self.assertEqual(
+            schema.errors("127.0.0"),
+            [Error("Not a valid IPv4 address")],
+        )
+        self.assertEqual(
+            schema.errors("a2.12.55.3"),
+            [Error("Not a valid IPv4 address")],
+        )
+
+
+    def test_ipv6address(self):
+        schema = IPv6Address()
+        self.assertEqual(
+            schema.errors("::2"),
+            [],
+        )
+        self.assertEqual(
+            schema.errors("abdf::4"),
+            [],
+        )
+        self.assertEqual(
+            schema.errors("34de:e23d::233e:32"),
+            [],
+        )
+        self.assertEqual(
+            schema.errors("::ffff:222.1.41.90"),
+            [],
+        )
+        self.assertEqual(
+            schema.errors("1232:d4af:6023:1afc:cfed:0239d:0934:0923d"),
+            [],
+        )
+        self.assertEqual(
+            schema.errors("1232:d4af:6023:1afc:cfed:0239d:0934:0923d:3421"),
+            [Error("Not a valid IPv6 address (too many colons)")],
+        )
+        self.assertEqual(
+            schema.errors("1:::42"),
+            [Error("Not a valid IPv6 address (shortener not bounded)")],
+        )
+        self.assertEqual(
+            schema.errors("1351:z::3"),
+            [Error("Not a valid IPv6 address (invalid hextet)")],
+        )
+        self.assertEqual(
+            schema.errors("dead:beef::3422:23::1"),
+            [Error("Not a valid IPv6 address (multiple shorteners)")],
+        )
+        self.assertEqual(
+            schema.errors("dead:beef::127.0.0.1:0"),
+            [Error("Not a valid IPv6 address (v4 section not at end)")],
+        )
+        self.assertEqual(
+            schema.errors("dead:beef::127.0.0.300"),
+            [Error("Not a valid IPv6 address (v4 section not valid address)")],
+        )
+
+    def test_ipaddress(self):
+        schema = IPAddress()
+        self.assertEqual(
+            schema.errors("127.34.22.11"),
+            [],
+        )
+        self.assertEqual(
+            schema.errors("1232:d4af:6023:1afc:cfed:0239d:0934:0923d"),
+            [],
+        )
+        self.assertEqual(
+            len(schema.errors("I LOVE FISH")),
+            2,
+        )


### PR DESCRIPTION
This adds three IP address fields: `IPv4Address`, `IPv6Address`, and `IPAddress`. The latter will accept either v4 or v6 addresses.

As part of this (it uses Any), I have removed the incorrect use of pointers in Any - all the errors point to the same variable, not to different indexes inside it.