### PR TITLE
Add BooleanValidator

### DIFF
--- a/conformity/fields/__init__.py
+++ b/conformity/fields/__init__.py
@@ -1,6 +1,6 @@
 from .basic import Base, Constant, Anything, Hashable, Boolean, Integer, Float, ByteString, UnicodeString  # noqa
 from .structures import List, Dictionary, SchemalessDictionary, Tuple  # noqa
-from .meta import Polymorph, ObjectInstance, Any, All  # noqa
+from .meta import Polymorph, ObjectInstance, Any, All, BooleanValidator  # noqa
 from .temporal import DateTime, Date, TimeDelta, Time, TZInfo  # noqa
 from .geo import Latitude, Longitude  # noqa
 from .net import IPAddress, IPv4Address, IPv6Address  # noqa

--- a/conformity/tests/test_fields_meta.py
+++ b/conformity/tests/test_fields_meta.py
@@ -10,6 +10,7 @@ from ..fields import (
     ObjectInstance,
     All,
     Any,
+    BooleanValidator,
 )
 from ..error import Error
 
@@ -152,5 +153,43 @@ class MetaFieldTests(unittest.TestCase):
                     },
                 },
                 "switch_field": "payment_type",
+            },
+        )
+
+    def test_boolean_validator(self):
+        schema = BooleanValidator(
+            lambda x: x.isdigit(),
+            "str.isdigit()",
+            "Not all digits",
+        )
+        # Test valid unicode and byte strings
+        self.assertEqual(
+            schema.errors("123"),
+            [],
+        )
+        self.assertEqual(
+            schema.errors(b"123"),
+            [],
+        )
+        # Test invalid unicode and byte strings
+        self.assertEqual(
+            len(schema.errors("123a")),
+            1,
+        )
+        self.assertEqual(
+            len(schema.errors(b"123a")),
+            1,
+        )
+        # Test bad-type errors are swallowed well
+        self.assertEqual(
+            len(schema.errors(344532)),
+            1,
+        )
+        # Test introspection looks OK
+        self.assertEqual(
+            schema.introspect(),
+            {
+                "type": "boolean_validator",
+                "validator": "str.isdigit()",
             },
         )


### PR DESCRIPTION
This is designed to primarily sit in an `All()` clause next to a type checker. It will swallow invalid-type errors/attribute errors and turn them into a normal Conformity error so that works well if the type one doesn't pass.