### PR TITLE
Allowed Constant to take multiple options for a more concise Any+Const

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@
 *.pyc
 *.eggs
 __pycache__
-
+.cache
 *.swp

--- a/conformity/tests/test_fields.py
+++ b/conformity/tests/test_fields.py
@@ -257,7 +257,7 @@ class FieldTests(unittest.TestCase):
                 "contents": [
                     {"type": "integer", "gt": 0},
                     {"type": "unicode"},
-                    {"type": "constant", "value": "I love tuples"},
+                    {"type": "constant", "values": ["I love tuples"]},
                 ]
             }
         )
@@ -334,4 +334,22 @@ class FieldTests(unittest.TestCase):
         self.assertEqual(
             schema.errors(-3.14159),
             [Error("Invalid decimal value (not unicode string)")],
+        )
+
+    def test_multi_constant(self):
+        """
+        Tests constants with multiple options
+        """
+        schema = Constant(42, 36, 81, 9231)
+        self.assertEqual(
+            schema.errors(9231),
+            [],
+        )
+        self.assertEqual(
+            schema.errors(81),
+            [],
+        )
+        self.assertEqual(
+            schema.errors(360000),
+            [Error("Value is not one of: 36, 42, 81, 9231")],
         )

--- a/conformity/tests/test_fields_meta.py
+++ b/conformity/tests/test_fields_meta.py
@@ -126,7 +126,7 @@ class MetaFieldTests(unittest.TestCase):
                             "account": {"type": "unicode"},
                             "payment_type": {
                                 "type": "constant",
-                                "value": "bankacc",
+                                "values": ["bankacc"],
                             },
                             "routing": {
                                 "type": "unicode",
@@ -146,7 +146,7 @@ class MetaFieldTests(unittest.TestCase):
                             "number": {"type": "unicode"},
                             "payment_type": {
                                 "type": "constant",
-                                "value": "card",
+                                "values": ["card"],
                             },
                         },
                         "optional_keys": [],


### PR DESCRIPTION
Since a lot of Any use was with constants, and the error messages were
long and a bit confusing, this gives the Constant field the ability to
have a set of options natively as multiple positional arguments to the
constructor. It's backwards compatible with the old calling style and
error messages, though the introspection format has changed.