### PR TITLE
Bump attrs, clean up imports, and add PyTest and coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@
 __pycache__
 .cache
 *.swp
+.idea
+*.iml
+.coverage
+coverage.xml
+pytests.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: false
 python:
     - '2.7'
     - '3.4'
+    - '3.5'
     - '3.6'
 
 install:

--- a/conformity/__init__.py
+++ b/conformity/__init__.py
@@ -1,1 +1,3 @@
-__version__ = "1.6.1"
+from __future__ import absolute_import
+
+from conformity.version import __version__, __version_info__  # noqa

--- a/conformity/error.py
+++ b/conformity/error.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 import attr
 
 

--- a/conformity/fields/__init__.py
+++ b/conformity/fields/__init__.py
@@ -1,9 +1,11 @@
-from .basic import (  # noqa
+from __future__ import absolute_import
+
+from conformity.fields.basic import (  # noqa
     Base, Constant, Anything, Hashable, Boolean,
     Integer, Float, ByteString, UnicodeString, UnicodeDecimal,
 )
-from .structures import List, Dictionary, SchemalessDictionary, Tuple  # noqa
-from .meta import Polymorph, ObjectInstance, Any, All, BooleanValidator  # noqa
-from .temporal import DateTime, Date, TimeDelta, Time, TZInfo  # noqa
-from .geo import Latitude, Longitude  # noqa
-from .net import IPAddress, IPv4Address, IPv6Address  # noqa
+from conformity.fields.structures import List, Dictionary, SchemalessDictionary, Tuple  # noqa
+from conformity.fields.meta import Polymorph, ObjectInstance, Any, All, BooleanValidator  # noqa
+from conformity.fields.temporal import DateTime, Date, TimeDelta, Time, TZInfo  # noqa
+from conformity.fields.geo import Latitude, Longitude  # noqa
+from conformity.fields.net import IPAddress, IPv4Address, IPv6Address  # noqa

--- a/conformity/fields/basic.py
+++ b/conformity/fields/basic.py
@@ -1,10 +1,12 @@
-from __future__ import unicode_literals
-import attr
+from __future__ import absolute_import, unicode_literals
+
 import decimal
+
+import attr
 import six
 
-from ..error import Error
-from ..utils import strip_none
+from conformity.error import Error
+from conformity.utils import strip_none
 
 
 @attr.s

--- a/conformity/fields/geo.py
+++ b/conformity/fields/geo.py
@@ -1,7 +1,8 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
+
 import attr
 
-from .basic import Float
+from conformity.fields.basic import Float
 
 
 @attr.s

--- a/conformity/fields/meta.py
+++ b/conformity/fields/meta.py
@@ -1,10 +1,11 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
+
 import attr
 import six
 
-from .basic import Base
-from ..error import Error
-from ..utils import strip_none
+from conformity.error import Error
+from conformity.fields.basic import Base
+from conformity.utils import strip_none
 
 
 @attr.s

--- a/conformity/fields/net.py
+++ b/conformity/fields/net.py
@@ -1,13 +1,15 @@
-from __future__ import unicode_literals
-import attr
+from __future__ import absolute_import, unicode_literals
+
 import functools
 import re
+
+import attr
 import six
 
-from ..error import Error
-from ..utils import strip_none
-from .basic import UnicodeString
-from .meta import Any
+from conformity.error import Error
+from conformity.fields.basic import UnicodeString
+from conformity.fields.meta import Any
+from conformity.utils import strip_none
 
 
 ipv4_regex = re.compile(r'^(25[0-5]|2[0-4]\d|[0-1]?\d?\d)(\.(25[0-5]|2[0-4]\d|[0-1]?\d?\d)){3}$')

--- a/conformity/fields/structures.py
+++ b/conformity/fields/structures.py
@@ -1,10 +1,15 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
+
 import attr
 import six
 
-from .basic import Base, Hashable, Anything
-from ..error import Error
-from ..utils import strip_none
+from conformity.error import Error
+from conformity.fields.basic import (
+    Anything,
+    Base,
+    Hashable,
+)
+from conformity.utils import strip_none
 
 
 def _update_error_pointer(error, pointer_or_prefix):

--- a/conformity/fields/temporal.py
+++ b/conformity/fields/temporal.py
@@ -1,10 +1,12 @@
-from __future__ import unicode_literals
-import attr
+from __future__ import absolute_import, unicode_literals
+
 import datetime
 
-from .basic import Base
-from ..error import Error
-from ..utils import strip_none
+import attr
+
+from conformity.error import Error
+from conformity.fields.basic import Base
+from conformity.utils import strip_none
 
 
 @attr.s

--- a/conformity/tests/test_fields.py
+++ b/conformity/tests/test_fields.py
@@ -1,23 +1,23 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
-import unittest
 import datetime
+import unittest
 
-from ..fields import (
-    UnicodeString,
-    Dictionary,
-    List,
-    Integer,
-    Float,
+from conformity.error import Error
+from conformity.fields import (
     Constant,
-    DateTime,
     Date,
-    TimeDelta,
+    DateTime,
+    Dictionary,
+    Float,
+    Integer,
+    List,
     SchemalessDictionary,
+    TimeDelta,
     Tuple,
     UnicodeDecimal,
+    UnicodeString,
 )
-from ..error import Error
 
 
 class FieldTests(unittest.TestCase):

--- a/conformity/tests/test_fields_geo.py
+++ b/conformity/tests/test_fields_geo.py
@@ -1,12 +1,12 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import unittest
 
-from ..fields import (
+from conformity.error import Error
+from conformity.fields import (
     Latitude,
     Longitude,
 )
-from ..error import Error
 
 
 class GeoFieldTests(unittest.TestCase):

--- a/conformity/tests/test_fields_meta.py
+++ b/conformity/tests/test_fields_meta.py
@@ -1,18 +1,18 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import unittest
 
-from ..fields import (
-    Constant,
-    Dictionary,
-    UnicodeString,
-    Polymorph,
-    ObjectInstance,
+from conformity.error import Error
+from conformity.fields import (
     All,
     Any,
     BooleanValidator,
+    Constant,
+    Dictionary,
+    ObjectInstance,
+    Polymorph,
+    UnicodeString,
 )
-from ..error import Error
 
 
 class MetaFieldTests(unittest.TestCase):

--- a/conformity/tests/test_fields_net.py
+++ b/conformity/tests/test_fields_net.py
@@ -1,13 +1,13 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import unittest
 
-from ..fields import (
+from conformity.error import Error
+from conformity.fields import (
     IPAddress,
     IPv4Address,
     IPv6Address,
 )
-from ..error import Error
 
 
 class NetFieldTests(unittest.TestCase):

--- a/conformity/tests/test_validator.py
+++ b/conformity/tests/test_validator.py
@@ -1,14 +1,17 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import unittest
 
-from ..fields import Dictionary, UnicodeString
-from ..validator import (
+from conformity.fields import (
+    Dictionary,
+    UnicodeString,
+)
+from conformity.validator import (
+    PositionalError,
     validate,
     validate_call,
     validate_method,
     ValidationError,
-    PositionalError
 )
 
 

--- a/conformity/validator.py
+++ b/conformity/validator.py
@@ -1,5 +1,7 @@
-import types
+from __future__ import absolute_import, unicode_literals
+
 from functools import partial, wraps
+import types
 
 
 class ValidationError(ValueError):

--- a/conformity/version.py
+++ b/conformity/version.py
@@ -1,0 +1,5 @@
+from __future__ import unicode_literals
+
+
+__version_info__ = (1, 6, 1)
+__version__ = '.'.join(map(str, __version_info__))

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,11 @@
 universal=1
 
 [flake8]
-exclude = .env/*,docs/*,build/*
-ignore = E123,E128,E402,W503,E731,W601
-max-line-length = 119
+exclude = .env/*,docs/*,build/*,.eggs/*
+max-line-length = 120
+
+[aliases]
+test=pytest
+
+[tool:pytest]
+addopts = -s --junitxml=pytests.xml --cov-report xml --cov-report term-missing --cov=conformity.error --cov=conformity.utils --cov=conformity.validator --cov=conformity.fields

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,16 @@
-from setuptools import setup, find_packages
+from __future__ import absolute_import, unicode_literals
+
+from setuptools import (
+    find_packages,
+    setup,
+)
+
 from conformity import __version__
+
+tests_require = [
+    'pytest',
+    'pytest-cov',
+]
 
 setup(
     name='conformity',
@@ -17,9 +28,14 @@ setup(
     include_package_data=True,
     install_requires=[
         'six',
-        'attrs~=16.3',
+        'attrs~=17.4',
     ],
     test_suite='conformity.tests',
+    tests_require=tests_require,
+    setup_requires=['pytest-runner'],
+    extras_require={
+        'testing': tests_require,
+    },
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
- Bump `attrs` from ~16.3 to ~17.4
- Clean up imports to follow our import style
- Add PyTest and code coverage calculation