### PR TITLE
Add support for specifying minimum required string length

### DIFF
--- a/conformity/fields/basic.py
+++ b/conformity/fields/basic.py
@@ -199,6 +199,7 @@ class UnicodeString(Base):
     valid_noun = "unicode string"
     introspect_type = "unicode"
 
+    min_length = attr.ib(default=None)
     max_length = attr.ib(default=None)
     description = attr.ib(default=None)
 
@@ -207,9 +208,13 @@ class UnicodeString(Base):
             return [
                 Error("Not a %s" % self.valid_noun),
             ]
+        elif self.min_length is not None and len(value) < self.min_length:
+            return [
+                Error("String must have a length of at least %s" % self.min_length),
+            ]
         elif self.max_length is not None and len(value) > self.max_length:
             return [
-                Error("String longer than %s" % self.max_length),
+                Error("String must have a length no more than %s" % self.max_length),
             ]
 
     def introspect(self):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -5,6 +5,7 @@ import unittest
 
 from conformity.error import Error
 from conformity.fields import (
+    ByteString,
     Constant,
     Date,
     DateTime,
@@ -24,6 +25,30 @@ class FieldTests(unittest.TestCase):
     """
     Tests fields
     """
+    def test_strings(self):
+        schema = UnicodeString()
+        self.assertEqual(None, schema.errors(""))
+        self.assertEqual(None, schema.errors("Foo bar baz qux foo bar baz qux foo bar baz qux foo bar baz qux foo bar"))
+        self.assertEqual([Error("Not a unicode string")], schema.errors(b"Test"))
+
+        schema = UnicodeString(min_length=5, max_length=10)
+        self.assertEqual([Error("String must have a length of at least 5")], schema.errors(""))
+        self.assertEqual([Error("String must have a length of at least 5")], schema.errors("1234"))
+        self.assertEqual(None, schema.errors("12345"))
+        self.assertEqual(None, schema.errors("1234567890"))
+        self.assertEqual([Error("String must have a length no more than 10")], schema.errors("12345678901"))
+
+        schema = ByteString()
+        self.assertEqual(None, schema.errors(b""))
+        self.assertEqual(None, schema.errors(b"Foo bar baz qux foo bar baz qux foo bar baz qux foo bar baz qux foo"))
+        self.assertEqual([Error("Not a byte string")], schema.errors("Test"))
+
+        schema = ByteString(min_length=5, max_length=10)
+        self.assertEqual([Error("String must have a length of at least 5")], schema.errors(b""))
+        self.assertEqual([Error("String must have a length of at least 5")], schema.errors(b"1234"))
+        self.assertEqual(None, schema.errors(b"12345"))
+        self.assertEqual(None, schema.errors(b"1234567890"))
+        self.assertEqual([Error("String must have a length no more than 10")], schema.errors(b"12345678901"))
 
     def test_complex(self):
 


### PR DESCRIPTION
The `List` field has minimum length and maximum length arguments. However, the `UnicodeString` and `ByteString` fields only have maximum length arguments. This means that someone could pass in an empty string to satisfy a field the service writer intends to be required. Adding a `min_length` argument should solve this.