### PR TITLE
Fix: Nullable introspection incorrectly squashed all inner introspection

### DIFF
--- a/conformity/fields/meta.py
+++ b/conformity/fields/meta.py
@@ -11,11 +11,12 @@ from conformity.utils import strip_none
 @attr.s
 class Nullable(Base):
     """
-    Accepts the field type passed as the first positional argument or a value of null/None.
+    Accepts the field type passed as the first positional argument or a value of null/None. Introspection is a
+    dictionary with "type" set to "nullable" and key "nullable" set to the introspection of the first positional
+    argument.
     """
 
     field = attr.ib()
-    description = attr.ib(default=None)
 
     def errors(self, value):
         if value is None:
@@ -24,10 +25,7 @@ class Nullable(Base):
         return self.field.errors(value)
 
     def introspect(self):
-        return strip_none({
-            "type": "nullable({})".format(self.field.introspect()),
-            "description": self.description,
-        })
+        return {"type": "nullable", "nullable": self.field.introspect()}
 
 
 @attr.s

--- a/tests/test_fields_meta.py
+++ b/tests/test_fields_meta.py
@@ -23,23 +23,29 @@ class MetaFieldTests(unittest.TestCase):
     """
 
     def test_nullable(self):
-        schema = Nullable(Constant("one", "two"))
+        constant = Constant("one", "two")
+        schema = Nullable(constant)
         self.assertEqual([], schema.errors(None))
         self.assertEqual([], schema.errors("one"))
         self.assertEqual([], schema.errors("two"))
         self.assertEqual(1, len(schema.errors("three")))
+        self.assertEqual({"type": "nullable", "nullable": constant.introspect()}, schema.introspect())
 
-        schema = Nullable(Boolean())
+        boolean = Boolean(description="This is a test description")
+        schema = Nullable(boolean)
         self.assertEqual([], schema.errors(None))
         self.assertIsNone(schema.errors(True))
         self.assertIsNone(schema.errors(False))
         self.assertEqual(1, len(schema.errors("true")))
         self.assertEqual(1, len(schema.errors(1)))
+        self.assertEqual({"type": "nullable", "nullable": boolean.introspect()}, schema.introspect())
 
-        schema = Nullable(UnicodeString())
+        string = UnicodeString()
+        schema = Nullable(string)
         self.assertEqual([], schema.errors(None))
         self.assertIsNone(schema.errors("hello, world"))
         self.assertEqual(1, len(schema.errors(b"hello, world")))
+        self.assertEqual({"type": "nullable", "nullable": string.introspect()}, schema.introspect())
 
     def test_any(self):
         schema = Any(Constant("one"), Constant("two"))


### PR DESCRIPTION
Introspection for the new `Nullable` field was incorrectly squashing inner introspection to a Python dict string. This breaks introspection. With this change, `Nullable` introspection defers to the first positional argument, but adds a `"nullable": True` key to the returned dictionary. If the returned dictionary has no description, the `Nullable` description will be used (if set).