### PR TITLE
[PATCH] Ensure optional_keys is a set, introspects to a list

### DIFF
--- a/conformity/fields/structures.py
+++ b/conformity/fields/structures.py
@@ -72,7 +72,7 @@ class Dictionary(Base):
     """
 
     contents = None
-    optional_keys = []
+    optional_keys = set()
     allow_extra_keys = False
     description = None
 
@@ -81,15 +81,17 @@ class Dictionary(Base):
         self.contents = contents
         if self.contents is None:
             self.contents = self.__class__.contents
+
         self.allow_extra_keys = allow_extra_keys
         if self.allow_extra_keys is None:
             self.allow_extra_keys = self.__class__.allow_extra_keys
-        self.optional_keys = optional_keys
-        if self.optional_keys is None:
-            self.optional_keys = self.__class__.optional_keys
+
+        self.optional_keys = set(optional_keys) if optional_keys else self.__class__.optional_keys
+
         self.description = description
         if self.description is None:
             self.description = self.__class__.description
+
         if self.contents is None:
             raise ValueError("contents is a required argument")
 
@@ -102,7 +104,7 @@ class Dictionary(Base):
         for key, field in self.contents.items():
             # Check key is present
             if key not in value:
-                if key not in (self.optional_keys or []):
+                if key not in self.optional_keys:
                     result.append(
                         Error("Key %s missing" % key, pointer=key),
                     )
@@ -127,7 +129,7 @@ class Dictionary(Base):
                 key: value.introspect()
                 for key, value in self.contents.items()
             },
-            "optional_keys": self.optional_keys,
+            "optional_keys": list(self.optional_keys),
             "allow_extra_keys": self.allow_extra_keys,
             "description": self.description,
         })

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -100,32 +100,33 @@ class FieldTests(unittest.TestCase):
             [],
         )
 
+        introspection = schema.introspect()
+        self.assertEqual("dictionary", introspection["type"])
+        self.assertFalse(introspection["allow_extra_keys"])
+        self.assertEqual([], introspection["optional_keys"])
+        self.assertEqual(2, len(introspection["contents"]))
+        self.assertIn("child_ids", introspection["contents"])
         self.assertEqual(
-            schema.introspect(),
             {
-                "type": "dictionary",
-                "allow_extra_keys": False,
-                "contents": {
-                    "address": {
-                        "type": "dictionary",
-                        "allow_extra_keys": False,
-                        "contents": {
-                            "city": {"type": "unicode"},
-                            "country": {"type": "unicode"},
-                            "line1": {"type": "unicode"},
-                            "line2": {"type": "unicode"},
-                            "postcode": {"type": "unicode"},
-                            "state": {"type": "unicode"},
-                        },
-                        "optional_keys": ["line2", "state"],
-                    },
-                    "child_ids": {
-                        "type": "list",
-                        "contents": {"gt": 0, "type": "integer"},
-                    },
-                },
-                "optional_keys": [],
+                "type": "list",
+                "contents": {"gt": 0, "type": "integer"},
             },
+            introspection["contents"]["child_ids"],
+        )
+        self.assertIn("address", introspection["contents"])
+        self.assertEqual("dictionary", introspection["contents"]["address"]["type"])
+        self.assertFalse(introspection["contents"]["address"]["allow_extra_keys"])
+        self.assertEqual({"line2", "state"}, set(introspection["contents"]["address"]["optional_keys"]))
+        self.assertEqual(
+            {
+                "city": {"type": "unicode"},
+                "country": {"type": "unicode"},
+                "line1": {"type": "unicode"},
+                "line2": {"type": "unicode"},
+                "postcode": {"type": "unicode"},
+                "state": {"type": "unicode"},
+            },
+            introspection["contents"]["address"]["contents"],
         )
 
     def test_temporal(self):


### PR DESCRIPTION
When the compiler inlines a `tuple` for the `in` comparison, a small `tuple` is considerably faster than the same values in a `set` or a `list` (though that advantage eventually disappears for large iterables). However, when the same values in a `set`, a `list`, and a `tuple` are passed to something as an argument, the speed advantage is clearly in the favor of `set` in all scenarios:

```
In [1]: s1 = {'a', 'b', 'c', 'd', 'e', 'f', 'g'}

In [2]: s2 = ['a', 'b', 'c', 'd', 'e', 'f', 'g']

In [3]: s3 = ('a', 'b', 'c', 'd', 'e', 'f', 'g')

In [4]: %timeit 'd' in s1
42.5 ns ± 2.11 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)

In [5]: %timeit 'd' in s2
78.7 ns ± 1.19 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)

In [6]: %timeit 'd' in s3
85.3 ns ± 2.07 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)

In [11]: %timeit 'h' in s1
39 ns ± 0.717 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)

In [12]: %timeit 'h' in s2
147 ns ± 1.25 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)

In [13]: %timeit 'h' in s3
155 ns ± 1.24 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)
```

This changes ensures that `optional_keys` will always be a `set`, for best possible performance. It also ensures that the introspection converts `optional_keys` to a list, so that it can be serialized using msgpack and JSON. This performance enhancement mirrors a similar enhancement made to `Constant`: https://github.com/eventbrite/conformity/blob/2641061a21983e43a49e5353234be381b09ffad0/conformity/fields/basic.py#L38