### PR TITLE
[MINOR] Make temporal type support more flexible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,8 @@ from conformity import __version__
 tests_require = [
     'pytest',
     'pytest-cov',
+    'freezegun',
+    'pytz',
 ]
 
 setup(


### PR DESCRIPTION
- `type(value) == datetime.tzinfo` can never be `True`. All time zone objects inherit frcom `tzinfo`, and so would always fail this test.
- `type(value) == datetime.datetime` and `type(value) == datetime.date` fail when under a Freezegun context. This makes it impossible to freeze time in a test and then send that time to or return it from a Conformity-enforced routine. We need to be more flexible and allow those types, dynamically, without breaking on the fact that `datetime.datetime` extends `datetime.date` but should not be a valid `Date`.