### PR TITLE
[MINOR] Add support for machine-readable error codes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,9 @@ Conformity
 
 A low-level, declarative schema validation library.
 
-Declare a schema::
+Declare a schema:
+
+.. code:: python
 
     person = Dictionary({
         "name": UnicodeString(),
@@ -21,14 +23,18 @@ Declare a schema::
         "event_ids": List(Integer(gt=0)),
     })
 
-Check to see if data is valid::
+Check to see if data is valid:
+
+.. code:: python
 
     data = {"name": "Andrew", "height": 180.3, "event_ids": [1, "3"]}
-    person.errors(data)
+    errors = person.errors(data)
 
     # Key event_ids: Index 1: Not an integer
 
-And wrap functions to validate on the way in and out::
+And wrap functions to validate on the way in and out:
+
+.. code:: python
 
     kwargs = Dictionary({
         "name": UnicodeString(),
@@ -38,13 +44,26 @@ And wrap functions to validate on the way in and out::
     @validate_call(kwargs, UnicodeString())
     def greet(name, score=0):
         if score > 10:
-            return "So nice to meet you, %s!" % name
+            return "So nice to meet you, {}!".format(name)
         else:
-            return "Hello, %s." % name
+            return "Hello, {}.".format(name)
 
-There's support for basic string, numeric, geographic, temporal, networking,
-and other field types, with everything easily extensible (optionally via
-subclassing)
+There's support for basic string, numeric, geographic, temporal, networking, and other field types, with everything
+easily extensible (optionally via subclassing).
+
+
+Errors are always instances of ``conformity.error:Error``, and each error has a ``message``, a ``code``, and a
+``pointer``:
+
+- ``message`` is a plain-language (English) explanation of the problem.
+- ``code`` is a machine-readable code that, in most cases, is ``INVALID`` (using the constant
+  ``conformity.error:ERROR_CODE_INVALID``). In ``Dictionary``s, the error code is ``MISSING`` (``ERROR_CODE_MISSING``)
+  for required keys that aren't present and ``UNKNOWN`` for extra keys that aren't allowed. In ``Constant``s, the error
+  code is ``UNKNOWN`` for values that don't match the allowed value or values. In ``Polymorph``s, the error code is
+  ``UNKNOWN`` for unknown switch values when no ``__default__`` is present.
+- ``pointer`` is ``None`` for errors in most field types. However, for data structure field types (``List``,
+  ``Dictionary``, ``SchemalessDictionary``, ``Tuple``), ``pointer`` is a string representing the dotted path to the
+  offending value in the structure.
 
 
 Interface
@@ -52,15 +71,12 @@ Interface
 
 Anything can be a Conformity validator as long as it follows this interface:
 
-* An ``errors(value)`` method, that returns a list of ``confirmity.Error``
-  objects for each error or an empty list if the value is clean.
+* An ``errors(value)`` method that returns a list of ``conformity.error:Error`` objects for each error or an empty
+  list or ``None`` if the value is clean.
 
-* An ``introspect()`` method, that returns a dictionary describing the field.
-  The format of this dictionary has to vary by field, but it should reflect the
-  names of keyword arguments passed into the constructor, and provide enough
-  information to entirely re-create the field as-is. Any sub-fields declared
-  for structures should be represented using their own ``introspect()`` output.
-  The dictionary must also contain a ``type`` key that contains the name of the
-  type, but this should use lower case and underscores rather than the class
-  name. It can also contain a ``description`` key which should be interpreted
-  as the human-readable reason for the field.
+* An ``introspect()`` method, that returns a dictionary describing the field. The format of this dictionary has to vary
+  by field, but it should reflect the names of keyword arguments passed into the constructor, and provide enough
+  information to entirely re-create the field as-is. Any sub-fields declared for structures should be represented using
+  their own ``introspect()`` output. The dictionary must also contain a ``type`` key that contains the name of the
+  type, but this should use lower case and underscores rather than the class name. It can also contain a ``description``
+  key which should be interpreted as the human-readable reason for the field.

--- a/conformity/error.py
+++ b/conformity/error.py
@@ -3,10 +3,16 @@ from __future__ import absolute_import, unicode_literals
 import attr
 
 
+ERROR_CODE_INVALID = "INVALID"
+ERROR_CODE_MISSING = "MISSING"
+ERROR_CODE_UNKNOWN = "UNKNOWN"
+
+
 @attr.s
 class Error(object):
     """
     Represents an error found validating against the schema.
     """
     message = attr.ib()
+    code = attr.ib(default=ERROR_CODE_INVALID)
     pointer = attr.ib(default=None)

--- a/conformity/fields/meta.py
+++ b/conformity/fields/meta.py
@@ -3,7 +3,10 @@ from __future__ import absolute_import, unicode_literals
 import attr
 import six
 
-from conformity.error import Error
+from conformity.error import (
+    Error,
+    ERROR_CODE_UNKNOWN,
+)
 from conformity.fields.basic import Base
 from conformity.utils import strip_none
 
@@ -51,7 +54,7 @@ class Polymorph(Base):
                 switch_value = "__default__"
             else:
                 return [
-                    Error("Invalid switch value %r" % switch_value),
+                    Error("Invalid switch value {}".format(switch_value), code=ERROR_CODE_UNKNOWN),
                 ]
         field = self.contents_map[switch_value]
         # Run field errors

--- a/conformity/fields/structures.py
+++ b/conformity/fields/structures.py
@@ -3,7 +3,11 @@ from __future__ import absolute_import, unicode_literals
 import attr
 import six
 
-from conformity.error import Error
+from conformity.error import (
+    Error,
+    ERROR_CODE_MISSING,
+    ERROR_CODE_UNKNOWN,
+)
 from conformity.fields.basic import (
     Anything,
     Base,
@@ -106,7 +110,7 @@ class Dictionary(Base):
             if key not in value:
                 if key not in self.optional_keys:
                     result.append(
-                        Error("Key %s missing" % key, pointer=key),
+                        Error("Missing key: {}".format(key), code=ERROR_CODE_MISSING, pointer=key),
                     )
             else:
                 # Check key type
@@ -118,7 +122,10 @@ class Dictionary(Base):
         extra_keys = set(value.keys()) - set(self.contents.keys())
         if extra_keys and not self.allow_extra_keys:
             result.append(
-                Error("Extra keys %s present" % (", ".join(six.text_type(key) for key in extra_keys))),
+                Error(
+                    "Extra keys present: {}".format(", ".join(six.text_type(key) for key in sorted(extra_keys))),
+                    code=ERROR_CODE_UNKNOWN,
+                ),
             )
         return result
 

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,12 @@ from setuptools import (
 
 from conformity import __version__
 
+
+def readme():
+    with open('README.rst') as f:
+        return f.read()
+
+
 tests_require = [
     'pytest',
     'pytest-cov',
@@ -20,21 +26,17 @@ setup(
     author='Eventbrite, Inc.',
     author_email='opensource@eventbrite.com',
     description='Cacheable schema description and validation',
-    long_description=(
-        'Conformity allows easy creation of schemas to be checked against '
-        'function calls, service calls, or other uses, designed in a manner '
-        'that allows heavy caching and is entirely deterministic.'
-        '\n\nFor more, see http://github.com/eventbrite/conformity/'
-    ),
-    packages=find_packages(),
+    long_description=readme(),
+    url='http://github.com/eventbrite/conformity',
+    packages=list(map(str, find_packages(exclude=['*.tests', '*.tests.*', 'tests.*', 'tests']))),
     include_package_data=True,
     install_requires=[
         'six',
         'attrs~=17.4',
     ],
-    test_suite='conformity.tests',
     tests_require=tests_require,
     setup_requires=['pytest-runner'],
+    test_suite='tests',
     extras_require={
         'testing': tests_require,
     },

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -6,7 +6,11 @@ import unittest
 import freezegun
 import pytz
 
-from conformity.error import Error
+from conformity.error import (
+    Error,
+    ERROR_CODE_MISSING,
+    ERROR_CODE_UNKNOWN,
+)
 from conformity.fields import (
     ByteString,
     Constant,
@@ -83,10 +87,13 @@ class FieldTests(unittest.TestCase):
         )
 
         self.assertEqual(
-            sorted(schema.errors({"child_ids": [1, 2, "ten"]})),
+            sorted(schema.errors(
+                {"child_ids": [1, 2, "ten"], "unsolicited_item": "Should not be here", "another_bad": "Also extra"},
+            )),
             sorted([
                 Error("Not a integer", pointer="child_ids.2"),
-                Error("Key address missing", pointer="address"),
+                Error("Missing key: address", code=ERROR_CODE_MISSING, pointer="address"),
+                Error("Extra keys present: another_bad, unsolicited_item", code=ERROR_CODE_UNKNOWN),
             ]),
         )
 
@@ -300,7 +307,8 @@ class FieldTests(unittest.TestCase):
                 Error('Value not > 0', pointer='0'),
                 Error('Not a unicode string', pointer='1'),
                 Error(
-                    'Value is not %r' % 'I love tuples',
+                    'Value is not "I love tuples"',
+                    code=ERROR_CODE_UNKNOWN,
                     pointer='2',
                 ),
             ]
@@ -407,5 +415,5 @@ class FieldTests(unittest.TestCase):
         )
         self.assertEqual(
             schema.errors(360000),
-            [Error("Value is not one of: 36, 42, 81, 9231")],
+            [Error("Value is not one of: 36, 42, 81, 9231", code=ERROR_CODE_UNKNOWN)],
         )


### PR DESCRIPTION
To better support clients that interpret received error codes to display helpful messages to humans, this adds support for machine-readable error codes to field validation. When not explicitly provided, the default error code is `INVALID`, which is appropriate in most cases. Missing keys in structures are `MISSING`. Extra keys in structures, and values that don't match expected constants, are `UNKNOWN`.