### PR TITLE
[MINOR] Add support for extending dictionaries to simplify similar schemas

### DIFF
--- a/conformity/fields/structures.py
+++ b/conformity/fields/structures.py
@@ -129,6 +129,43 @@ class Dictionary(Base):
             )
         return result
 
+    def extend(
+        self,
+        contents=None,
+        optional_keys=None,
+        allow_extra_keys=None,
+        description=None,
+        replace_optional_keys=False,
+    ):
+        """
+        This method allows you to create a new `Dictionary` that extends the current `Dictionary` with additional
+        contents and/or optional keys, and/or replaces the `allow_extra_keys` and/or `description` attributes.
+
+        :param contents: More contents, if any, to extend the current contents
+        :type contents: dict
+        :param optional_keys: More optional keys, if any, to extend the current optional keys
+        :type optional_keys: union[set, list, tuple]
+        :param allow_extra_keys: If non-`None`, this overrides the current `allow_extra_keys` attribute
+        :type allow_extra_keys: bool
+        :param description: If non-`None`, this overrides the current `description` attribute
+        :type description: union[str, unicode]
+        :param replace_optional_keys: If `True`, then the `optional_keys` argument will completely replace, instead of
+                                      extend, the current optional keys
+        :type replace_optional_keys: bool
+
+        :return: A new `Dictionary` extended from the current `Dictionary` based on the supplied arguments
+        :rtype: Dictionary
+        """
+        optional_keys = set(optional_keys or [])
+        return Dictionary(
+            contents={
+                k: v for d in (self.contents, contents) for k, v in six.iteritems(d)
+            } if contents else self.contents,
+            optional_keys=optional_keys if replace_optional_keys else self.optional_keys | optional_keys,
+            allow_extra_keys=self.allow_extra_keys if allow_extra_keys is None else allow_extra_keys,
+            description=self.description if description is None else description,
+        )
+
     def introspect(self):
         return strip_none({
             "type": "dictionary",

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -12,6 +12,7 @@ from conformity.error import (
     ERROR_CODE_UNKNOWN,
 )
 from conformity.fields import (
+    Boolean,
     ByteString,
     Constant,
     Date,
@@ -138,6 +139,63 @@ class FieldTests(unittest.TestCase):
                 "state": {"type": "unicode"},
             },
             introspection["contents"]["address"]["contents"],
+        )
+
+    def test_dictionary_extension(self):
+        schema1 = Dictionary(
+            {
+                'foo': UnicodeString(),
+                'bar': Boolean(),
+            },
+            optional_keys=('foo', ),
+            description='Hello, world',
+        )
+
+        schema2 = schema1.extend(
+            {
+                'bar': Integer(),
+                'baz': List(Integer()),
+            },
+            optional_keys=('baz', ),
+        )
+
+        schema3 = schema1.extend(
+            {
+                'bar': Integer(),
+                'baz': List(Integer()),
+            },
+            optional_keys=('baz',),
+            allow_extra_keys=True,
+            description='Goodbye, universe',
+            replace_optional_keys=True,
+        )
+
+        self.assertEqual(
+            Dictionary(
+                {
+                    'foo': UnicodeString(),
+                    'bar': Integer(),
+                    'baz': List(Integer()),
+                },
+                optional_keys=('foo', 'baz', ),
+                allow_extra_keys=False,
+                description='Hello, world',
+            ).introspect(),
+            schema2.introspect(),
+        )
+
+        self.assertEqual(
+            Dictionary(
+                {
+                    'foo': UnicodeString(),
+                    'bar': Integer(),
+                    'baz': List(Integer()),
+                },
+                optional_keys=('baz',),
+                allow_extra_keys=True,
+                description='Goodbye, universe',
+            ).introspect(),
+            schema3.introspect(),
         )
 
     def test_temporal(self):


### PR DESCRIPTION
If we can extend a `Dictionary`, we can more easily have an overriding class or method define a schema that builds on the base schema, without having to redefine the entire schema or implement hacky solutions that copy the attributes of the base schema manually.