### PR TITLE
[MINOR] Fix three bugs in the email field

### DIFF
--- a/conformity/fields/email.py
+++ b/conformity/fields/email.py
@@ -17,9 +17,9 @@ class EmailAddress(UnicodeString):
     https://github.com/django/django/blob/stable/2.0.x/django/core/validators.py#L164
     UTF-8 emails are not supported in general.
     """
-    message = 'Enter a valid email address.'
-    code = 'invalid'
     ip_schema = IPAddress()
+    message = None  # unused, will be removed in version 2.0.0
+    code = None  # unused, will be removed in version 2.0.0
 
     user_regex = re.compile(
         r"(^[-!#$%&'*+/=?^_`{}|~0-9A-Z]+(\.[-!#$%&'*+/=?^_`{}|~0-9A-Z]+)*\Z"  # dot-atom
@@ -39,12 +39,16 @@ class EmailAddress(UnicodeString):
     domain_whitelist = ['localhost']
 
     def __init__(self, message=None, code=None, whitelist=None):
-        if message is not None:
-            self.message = message
-        if code is not None:
-            self.code = code
+        """
+        Construct a new email address field.
+
+        :param message: Unused, and will be removed in version 2.0.0
+        :param code: Unused, and will be removed in version 2.0.0
+        :param whitelist: If specified, an invalid domain part will be permitted if it is in this list
+        :type whitelist: iterable
+        """
         if whitelist is not None:
-            self.domain_whitelist = whitelist
+            self.domain_whitelist = set(whitelist) if whitelist else set()
 
     def errors(self, value):
         # Get any basic type errors
@@ -56,7 +60,7 @@ class EmailAddress(UnicodeString):
 
         user_part, domain_part = value.rsplit('@', 1)
         if not self.user_regex.match(user_part):
-            return [Error('Not a valid email address (invalid local user field)', user_part)]
+            return [Error('Not a valid email address (invalid local user field)', pointer=user_part)]
         if domain_part in self.domain_whitelist or self.is_domain_valid(domain_part):
             return []
         else:
@@ -66,7 +70,7 @@ class EmailAddress(UnicodeString):
                     return []
             except UnicodeError:
                 pass
-            return [Error('Not a valid email address (invalid domain field)', domain_part)]
+            return [Error('Not a valid email address (invalid domain field)', pointer=domain_part)]
 
     @classmethod
     def is_domain_valid(cls, domain_part):

--- a/tests/test_fields_email.py
+++ b/tests/test_fields_email.py
@@ -49,23 +49,23 @@ class EmailFieldTests(unittest.TestCase):
 
         self.assertEqual(
             schema.errors('A@b@c@example.com'),
-            [Error('Not a valid email address (invalid local user field)', 'A@b@c')],
+            [Error('Not a valid email address (invalid local user field)', pointer='A@b@c')],
         )
         self.assertEqual(
             schema.errors('a"b(c)d,e:f;g<h>i[j\k]l@example.com'),
-            [Error('Not a valid email address (invalid local user field)', 'a"b(c)d,e:f;g<h>i[j\\k]l')],
+            [Error('Not a valid email address (invalid local user field)', pointer='a"b(c)d,e:f;g<h>i[j\\k]l')],
         )
         self.assertEqual(
             schema.errors('just"not"right@example.com'),
-            [Error('Not a valid email address (invalid local user field)', 'just"not"right')],
+            [Error('Not a valid email address (invalid local user field)', pointer='just"not"right')],
         )
         self.assertEqual(
             schema.errors('this is"not\allowed@example.com'),
-            [Error('Not a valid email address (invalid local user field)', 'this is"not\x07llowed')],
+            [Error('Not a valid email address (invalid local user field)', pointer='this is"not\x07llowed')],
         )
         self.assertEqual(
             schema.errors('this\ still\"not\\allowed@example.com'),
-            [Error('Not a valid email address (invalid local user field)', 'this\\ still"not\\allowed')],
+            [Error('Not a valid email address (invalid local user field)', pointer='this\\ still"not\\allowed')],
         )
         # self.assertEqual(
         #     schema.errors('1234567890123456789012345678901234567890123456789012345678901234+x@example.com'),
@@ -73,38 +73,38 @@ class EmailFieldTests(unittest.TestCase):
         # )
         self.assertEqual(
             schema.errors('john..doe@example.com'),
-            [Error('Not a valid email address (invalid local user field)', 'john..doe')]
+            [Error('Not a valid email address (invalid local user field)', pointer='john..doe')]
         )
         self.assertEqual(
             schema.errors('john.doe@example..com'),
-            [Error('Not a valid email address (invalid domain field)', 'example..com')],
+            [Error('Not a valid email address (invalid domain field)', pointer='example..com')],
         )
         self.assertEqual(
             schema.errors('" "@example.org'),
-            [Error('Not a valid email address (invalid local user field)', '" "')],
+            [Error('Not a valid email address (invalid local user field)', pointer='" "')],
         )
         # Internationalization, currently not supported
         self.assertEqual(
             schema.errors('Pelé@example.com'),
-            [Error('Not a valid email address (invalid local user field)', 'Pelé')],
+            [Error('Not a valid email address (invalid local user field)', pointer='Pelé')],
         )
         self.assertEqual(
             schema.errors('δοκιμή@παράδειγμα.δοκιμή'),
-            [Error('Not a valid email address (invalid local user field)', 'δοκιμή')],
+            [Error('Not a valid email address (invalid local user field)', pointer='δοκιμή')],
         )
         self.assertEqual(
             schema.errors('我買@屋企.香港'),
-            [Error('Not a valid email address (invalid local user field)', '我買')],
+            [Error('Not a valid email address (invalid local user field)', pointer='我買')],
         )
         self.assertEqual(
             schema.errors('甲斐@黒川.日本'),
-            [Error('Not a valid email address (invalid local user field)', '甲斐')],
+            [Error('Not a valid email address (invalid local user field)', pointer='甲斐')],
         )
         self.assertEqual(
             schema.errors('чебурашка@ящик-с-апельсинами.рф'),
-            [Error('Not a valid email address (invalid local user field)', 'чебурашка')],
+            [Error('Not a valid email address (invalid local user field)', pointer='чебурашка')],
         )
         self.assertEqual(
             schema.errors('संपर्क@डाटामेल.भारत'),
-            [Error('Not a valid email address (invalid local user field)', 'संपर्क')],
+            [Error('Not a valid email address (invalid local user field)', pointer='संपर्क')],
         )


### PR DESCRIPTION
There were three bugs in the email field (and the fix is in parentheses):
- Unused `code` constructor parameter (deprecated)
- Unused `message` constructor parameter (deprecated)
- Error implicit pointers improperly became error codes when codes were added between messages and pointers (made them explicit pointers)