### PR TITLE
Include import in readme example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,8 @@ Declare a schema:
 
 .. code:: python
 
+    from conformity.fields import Dictionary, Float, List, UnicodeString
+
     person = Dictionary({
         "name": UnicodeString(),
         "height": Float(gte=0),

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Declare a schema:
 
 .. code:: python
 
-    from conformity.fields import Dictionary, Float, List, UnicodeString
+    from conformity.fields import Dictionary, Float, Integer, List, UnicodeString
 
     person = Dictionary({
         "name": UnicodeString(),


### PR DESCRIPTION
I guessed `from conformity import ...` and had to read the code to find out it was `from conformity.fields ...`