### PR TITLE
[PATCH] Field subclasses that use Attrs must use attr.s

### DIFF
--- a/conformity/fields/basic.py
+++ b/conformity/fields/basic.py
@@ -254,6 +254,7 @@ class ByteString(UnicodeString):
     introspect_type = "bytes"
 
 
+@attr.s
 class UnicodeDecimal(Base):
     """
     A decimal value represented as its base-10 unicode string.


### PR DESCRIPTION
If a field subclass uses Attrs (such as `attr.ib`), it must be decorated with `@attr.s`, otherwise the attributes in it aren't handled properly.