### PR TITLE
[PATCH] Permit a newer Attrs version and confirm it works

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: python
+dist: xenial
 sudo: false
 python:
   - '2.7'
   - '3.4'
   - '3.5'
   - '3.6'
+  - '3.7'
 install:
   - pip install -U pip setuptools flake8
 script:

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'six',
-        'attrs~=17.4',
+        'attrs>=17.4,<19',
     ],
     tests_require=tests_require,
     setup_requires=['pytest-runner'],


### PR DESCRIPTION
This commit premits a newer Attrs version and confirms that it works by passing all tests. Additionally, all tests pass with PyTest 4.0.0, so no changes are needed to support that. Finally, it adds a Python 3.7 Travis build to confirm proper operation on Python 3.7.