### PR TITLE
Fix TypeErrors when checking against an improper value type

### DIFF
--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -4,6 +4,7 @@ import unittest
 
 from conformity.fields import (
     Dictionary,
+    List,
     UnicodeString,
 )
 from conformity.validator import (
@@ -95,3 +96,17 @@ class ValidatorTests(unittest.TestCase):
 
         with self.assertRaises(PositionalError):
             Greeter.greeter("Andrew")
+
+    def test_validate_dict_base_type(self):
+        schema = Dictionary({
+            'unicode_name': UnicodeString,
+        })
+
+        with self.assertRaises(ValidationError):
+            validate(schema, {'unicode_name': 'John Smith'})
+
+    def test_validate_list_base_type(self):
+        schema = List(UnicodeString)
+
+        with self.assertRaises(ValidationError):
+            validate(schema, ['John Smith'])


### PR DESCRIPTION
When using badly constructed schemas like:
```
schema = Dictionary({
    'unicode_name': UnicodeString,
})
```
Sometimes is easy to miss that you typed `UnicodeString` instead of `UnicodeString()`. In those cases you see an uncontrolled (and sometimes cryptic) error like:
```
TypeError: unbound method errors() must be called with UnicodeString instance as first argument (got unicode instance instead)
```
This PR take this into account and raises a proper `ValidationError` with a message such as:
```
E           ValidationError: Invalid value:
E             - unicode_name: Invalid type, it must extend <class 'conformity.fields.basic.Base'>
```