### PR TITLE
[MINOR] Adds introspect_type attribute to all fields

### DIFF
--- a/conformity/fields/basic.py
+++ b/conformity/fields/basic.py
@@ -37,6 +37,8 @@ class Constant(Base):
     and any will be accepted.
     """
 
+    introspect_type = "constant"
+
     def __init__(self, *args, **kwargs):
         self.values = set(args)
         if not self.values:
@@ -65,7 +67,7 @@ class Constant(Base):
 
     def introspect(self):
         result = {
-            "type": "constant",
+            "type": self.introspect_type,
             "values": list(self.values),
         }
         if self.description is not None:
@@ -79,6 +81,7 @@ class Anything(Base):
     Accepts any value.
     """
 
+    introspect_type = "anything"
     description = attr.ib(default=None)
 
     def errors(self, value):
@@ -86,7 +89,7 @@ class Anything(Base):
 
     def introspect(self):
         return strip_none({
-            "type": "anything",
+            "type": self.introspect_type,
             "description": self.description,
         })
 
@@ -95,6 +98,8 @@ class Hashable(Anything):
     """
     Accepts any hashable value
     """
+
+    introspect_type = "hashable"
 
     def errors(self, value):
         try:
@@ -106,7 +111,7 @@ class Hashable(Anything):
 
     def introspect(self):
         return strip_none({
-            "type": "hashable",
+            "type": self.introspect_type,
             "description": self.description,
         })
 
@@ -116,6 +121,8 @@ class Boolean(Base):
     """
     Accepts boolean values only
     """
+
+    introspect_type = "boolean"
 
     description = attr.ib(default=None)
 
@@ -127,7 +134,7 @@ class Boolean(Base):
 
     def introspect(self):
         return strip_none({
-            "type": "boolean",
+            "type": self.introspect_type,
             "description": self.description,
         })
 
@@ -195,6 +202,7 @@ class Decimal(Integer):
     """
     Accepts arbitrary-precision Decimal number objects.
     """
+
     valid_type = decimal.Decimal
     valid_noun = "decimal"
     introspect_type = "decimal"
@@ -234,7 +242,6 @@ class UnicodeString(Base):
             ]
 
     def introspect(self):
-
         return strip_none({
             "type": self.introspect_type,
             "description": self.description,
@@ -260,6 +267,7 @@ class UnicodeDecimal(Base):
     A decimal value represented as its base-10 unicode string.
     """
 
+    introspect_type = "unicode_decimal"
     description = attr.ib(default=None)
 
     def errors(self, value):
@@ -277,6 +285,6 @@ class UnicodeDecimal(Base):
 
     def introspect(self):
         return strip_none({
-            "type": "unicode_decimal",
+            "type": self.introspect_type,
             "description": self.description,
         })

--- a/conformity/fields/currency.py
+++ b/conformity/fields/currency.py
@@ -16,6 +16,8 @@ class Amount(fields.Base):
     """
     currint.Amount instances
     """
+
+    introspect_type = "currint.Amount"
     valid_currencies = attr.ib(default=currint.currencies.keys())
     gt = attr.ib(default=None)
     gte = attr.ib(default=None)
@@ -65,7 +67,7 @@ class Amount(fields.Base):
 
     def introspect(self):
         return strip_none({
-            "type": "currint.Amount",
+            "type": self.introspect_type,
             "description": self.description,
             "valid_currencies": self.valid_currencies,
             "gt": self.gt,

--- a/conformity/fields/email.py
+++ b/conformity/fields/email.py
@@ -17,6 +17,8 @@ class EmailAddress(UnicodeString):
     https://github.com/django/django/blob/stable/2.0.x/django/core/validators.py#L164
     UTF-8 emails are not supported in general.
     """
+
+    introspect_type = "email_address"
     ip_schema = IPAddress()
     message = None  # unused, will be removed in version 2.0.0
     code = None  # unused, will be removed in version 2.0.0
@@ -88,6 +90,6 @@ class EmailAddress(UnicodeString):
 
     def introspect(self):
         return strip_none({
-            "type": "email_address",
+            "type": self.introspect_type,
             "description": self.description,
         })

--- a/conformity/fields/meta.py
+++ b/conformity/fields/meta.py
@@ -19,6 +19,7 @@ class Nullable(Base):
     argument.
     """
 
+    introspect_type = "nullable"
     field = attr.ib()
 
     def errors(self, value):
@@ -28,7 +29,10 @@ class Nullable(Base):
         return self.field.errors(value)
 
     def introspect(self):
-        return {"type": "nullable", "nullable": self.field.introspect()}
+        return {
+            "type": self.introspect_type,
+            "nullable": self.field.introspect(),
+        }
 
 
 @attr.s
@@ -38,6 +42,7 @@ class Polymorph(Base):
     within it (which must be accessible via dictionary lookups)
     """
 
+    introspect_type = "polymorph"
     switch_field = attr.ib()
     contents_map = attr.ib()
     description = attr.ib(default=None)
@@ -62,13 +67,13 @@ class Polymorph(Base):
 
     def introspect(self):
         return strip_none({
-            "type": "polymorph",
+            "type": self.introspect_type,
             "description": self.description,
             "switch_field": self.switch_field,
             "contents_map": {
                 key: value.introspect()
                 for key, value in self.contents_map.items()
-            }
+            },
         })
 
 
@@ -78,6 +83,7 @@ class ObjectInstance(Base):
     Accepts only instances of a given class or type
     """
 
+    introspect_type = "object_instance"
     valid_type = attr.ib()
     description = attr.ib(default=None)
 
@@ -91,7 +97,7 @@ class ObjectInstance(Base):
 
     def introspect(self):
         return strip_none({
-            "type": "object_instance",
+            "type": self.introspect_type,
             "description": self.description,
             # Unfortunately, this is the one sort of thing we can't represent
             # super well. Maybe add some dotted path stuff in here.
@@ -105,6 +111,7 @@ class Any(Base):
     Intended to be used for constants but could be used with others.
     """
 
+    introspect_type = "any"
     description = None
 
     def __init__(self, *args, **kwargs):
@@ -129,7 +136,7 @@ class Any(Base):
 
     def introspect(self):
         return strip_none({
-            "type": "any",
+            "type": self.introspect_type,
             "description": self.description,
             "options": [option.introspect() for option in self.options],
         })
@@ -141,6 +148,7 @@ class All(Base):
     Intended to be used for adding extra validation.
     """
 
+    introspect_type = "all"
     description = None
 
     def __init__(self, *args, **kwargs):
@@ -160,7 +168,7 @@ class All(Base):
 
     def introspect(self):
         return strip_none({
-            "type": "all",
+            "type": self.introspect_type,
             "description": self.description,
             "requirements": [requirement.introspect() for requirement in self.requirements],
         })
@@ -173,6 +181,7 @@ class BooleanValidator(Base):
     based on if it returns True (valid) or False (invalid).
     """
 
+    introspect_type = "boolean_validator"
     validator = attr.ib()
     validator_description = attr.ib(validator=attr.validators.instance_of(six.text_type))
     error = attr.ib(validator=attr.validators.instance_of(six.text_type))
@@ -196,7 +205,7 @@ class BooleanValidator(Base):
 
     def introspect(self):
         return strip_none({
-            "type": "boolean_validator",
+            "type": self.introspect_type,
             "description": self.description,
             "validator": self.validator_description,
         })

--- a/conformity/fields/net.py
+++ b/conformity/fields/net.py
@@ -18,6 +18,8 @@ ipv4_regex = re.compile(r'^(25[0-5]|2[0-4]\d|[0-1]?\d?\d)(\.(25[0-5]|2[0-4]\d|[0
 @attr.s
 class IPv4Address(UnicodeString):
 
+    introspect_type = "ipv4_address"
+
     def errors(self, value):
         # Get any basic type errors
         result = super(IPv4Address, self).errors(value)
@@ -31,13 +33,15 @@ class IPv4Address(UnicodeString):
 
     def introspect(self):
         return strip_none({
-            "type": "ipv4_address",
+            "type": self.introspect_type,
             "description": self.description,
         })
 
 
 @attr.s
 class IPv6Address(UnicodeString):
+
+    introspect_type = "ipv6_address"
 
     def errors(self, value):
         # Get any basic type errors
@@ -115,7 +119,7 @@ class IPv6Address(UnicodeString):
 
     def introspect(self):
         return strip_none({
-            "type": "ipv6_address",
+            "type": self.introspect_type,
             "description": self.description,
         })
 

--- a/conformity/fields/structures.py
+++ b/conformity/fields/structures.py
@@ -41,6 +41,7 @@ class List(Base):
 
     valid_types = list
     type_noun = "list"
+    introspect_type = type_noun
     type_error = "Not a list"
 
     def errors(self, value):
@@ -72,7 +73,7 @@ class List(Base):
 
     def introspect(self):
         return strip_none({
-            "type": self.type_noun,
+            "type": self.introspect_type,
             "contents": self.contents.introspect(),
             "max_length": self.max_length,
             "min_length": self.min_length,
@@ -87,6 +88,7 @@ class List(Base):
 class Set(List):
     valid_types = (set, frozenset)
     type_noun = "set"
+    introspect_type = type_noun
     type_error = "Not a set or frozenset"
 
     class LazyPointer(object):
@@ -99,6 +101,7 @@ class Dictionary(Base):
     A dictionary with types per key (and requirements per key).
     """
 
+    introspect_type = "dictionary"
     contents = None
     optional_keys = set()
     allow_extra_keys = False
@@ -192,7 +195,7 @@ class Dictionary(Base):
 
     def introspect(self):
         return strip_none({
-            "type": "dictionary",
+            "type": self.introspect_type,
             "contents": {
                 key: value.introspect()
                 for key, value in self.contents.items()
@@ -209,6 +212,7 @@ class SchemalessDictionary(Base):
     Generic dictionary with requirements about key and value types, but not specific keys
     """
 
+    introspect_type = "schemaless_dictionary"
     key_type = attr.ib(default=attr.Factory(Hashable))
     value_type = attr.ib(default=attr.Factory(Anything))
     description = attr.ib(default=None)
@@ -232,7 +236,7 @@ class SchemalessDictionary(Base):
 
     def introspect(self):
         result = {
-            "type": "schemaless_dictionary",
+            "type": self.introspect_type,
             "description": self.description,
         }
         # We avoid using isinstance() here as that would also match subclass instances
@@ -247,6 +251,8 @@ class Tuple(Base):
     """
     A tuple with types per element.
     """
+
+    introspect_type = "tuple"
 
     def __init__(self, *contents, **kwargs):
         # We can't use attrs here because we need to capture all positional
@@ -278,7 +284,7 @@ class Tuple(Base):
 
     def introspect(self):
         return strip_none({
-            "type": "tuple",
+            "type": self.introspect_type,
             "contents": [value.introspect() for value in self.contents],
             "description": self.description,
         })


### PR DESCRIPTION
Adds `introspect_type` attribute to all field types. This allows to query any field class for its type literal (all non-derived ones currently have the `type` hardcoded at the `introspect()` method).

The reasoning is that I'm building a small tool that uses Conformity and right now I would have to hardcode a mapping of type literals and their associated conformity.field classes. This way each field states the value, without affecting normal behaviour of introspect() etc.

Caveats:
- I replaced the `type_noun` field at `List` and `Set`, but only to be coherent with other places where `introspect_type` was used for the same meaning, so I might be wrong.
- This introduces the danger of somebody inheriting an existing field and forgetting to replace the `introspect_type` value, but IMHO benefits are better and this can be checked on pull requests by the reviewers (but I could also add some comment to the README, or any alternative you see best).