### PR TITLE
Fix EmailAddress whitelist not working

### DIFF
--- a/conformity/fields/email.py
+++ b/conformity/fields/email.py
@@ -38,9 +38,20 @@ class EmailAddress(UnicodeString):
         r'\[([A-f0-9:\.]+)\]\Z',
         re.IGNORECASE
     )
-    domain_whitelist = ['localhost']
+    whitelist = attr.ib(default=set(['localhost']), type=set)
 
-    whitelist = attr.ib(default=[], type=list)
+    def __init__(self, message=None, code=None, whitelist=None):
+        """
+        Construct a new email address field.
+
+        :param message: Unused, and will be removed in version 2.0.0
+        :param code: Unused, and will be removed in version 2.0.0
+        :param whitelist: If specified, an invalid domain part will be permitted if it is in this list
+        :type whitelist: iterable
+        """
+        super(UnicodeString, self).__init__()
+        if whitelist is not None:
+            self.whitelist = set(whitelist) if whitelist else set()
 
     def errors(self, value):
         # Get any basic type errors

--- a/conformity/fields/email.py
+++ b/conformity/fields/email.py
@@ -40,17 +40,7 @@ class EmailAddress(UnicodeString):
     )
     domain_whitelist = ['localhost']
 
-    def __init__(self, message=None, code=None, whitelist=None):
-        """
-        Construct a new email address field.
-
-        :param message: Unused, and will be removed in version 2.0.0
-        :param code: Unused, and will be removed in version 2.0.0
-        :param whitelist: If specified, an invalid domain part will be permitted if it is in this list
-        :type whitelist: iterable
-        """
-        if whitelist is not None:
-            self.domain_whitelist = set(whitelist) if whitelist else set()
+    whitelist = attr.ib(default=[], type=list)
 
     def errors(self, value):
         # Get any basic type errors
@@ -63,7 +53,7 @@ class EmailAddress(UnicodeString):
         user_part, domain_part = value.rsplit('@', 1)
         if not self.user_regex.match(user_part):
             return [Error('Not a valid email address (invalid local user field)', pointer=user_part)]
-        if domain_part in self.domain_whitelist or self.is_domain_valid(domain_part):
+        if domain_part in self.whitelist or self.is_domain_valid(domain_part):
             return []
         else:
             try:

--- a/conformity/fields/email.py
+++ b/conformity/fields/email.py
@@ -37,32 +37,18 @@ class EmailAddress(UnicodeString):
     )
     domain_whitelist = ['localhost']
 
-    def __init__(
-        self,
-        message=None,
-        code=None,
-        min_length=None,
-        max_length=None,
-        description=None,
-        whitelist=None
-    ):
+    def __init__(self, message=None, code=None, whitelist=None, **kwargs):
         """
         Construct a new email address field.
 
         :param message: Unused, and will be removed in version 2.0.0
         :param code: Unused, and will be removed in version 2.0.0
-        :param min_length: If specified, minimum valid email length
-        :param max_legnth: If specified, maximum valid email length
-        :param description: If specified, user-friendly description of the field
         :param whitelist: If specified, an invalid domain part will be permitted if it is in this list
         :type whitelist: iterable
+        :param kwargs
         """
 
-        super(UnicodeString, self).__init__()
-        self.min_length = min_length
-        self.max_length = max_length
-        self.description = description
-        self.allow_blank = False
+        super(EmailAddress, self).__init__(**kwargs)
         if whitelist is not None:
             self.domain_whitelist = set(whitelist) if whitelist else set()
 

--- a/tests/test_fields_email.py
+++ b/tests/test_fields_email.py
@@ -131,3 +131,8 @@ class EmailFieldTests(unittest.TestCase):
             schema.errors('a-name@a-whitelisted-domain'),
             [],
         )
+
+    def test_whitelist_removes_duplicates(self):
+        whitelisted_domains = ['a-repeated-whitelisted-domain', 'a-repeated-whitelisted-domain']
+        schema = EmailAddress(whitelist=whitelisted_domains)
+        self.assertEqual(1, len(schema.whitelist))

--- a/tests/test_fields_email.py
+++ b/tests/test_fields_email.py
@@ -108,3 +108,26 @@ class EmailFieldTests(unittest.TestCase):
             schema.errors('संपर्क@डाटामेल.भारत'),
             [Error('Not a valid email address (invalid local user field)', pointer='संपर्क')],
         )
+
+    def test_non_whitelisted_address(self):
+        whitelisted_domains = ['a-whitelisted-domain']
+        schema = EmailAddress(whitelist=whitelisted_domains)
+        self.assertEqual(
+            schema.errors('a-name@non-whitelisted-domain'),
+            [Error('Not a valid email address (invalid domain field)', pointer='non-whitelisted-domain')],
+        )
+
+    def test_valid_non_whitelisted_address(self):
+        schema = EmailAddress()
+        self.assertEqual(
+            schema.errors('a-name@a-valid-domain.test'),
+            [],
+        )
+
+    def test_whitelisted_address_via_constructor(self):
+        whitelisted_domains = ['a-whitelisted-domain']
+        schema = EmailAddress(whitelist=whitelisted_domains)
+        self.assertEqual(
+            schema.errors('a-name@a-whitelisted-domain'),
+            [],
+        )

--- a/tests/test_fields_email.py
+++ b/tests/test_fields_email.py
@@ -135,4 +135,4 @@ class EmailFieldTests(unittest.TestCase):
     def test_whitelist_removes_duplicates(self):
         whitelisted_domains = ['a-repeated-whitelisted-domain', 'a-repeated-whitelisted-domain']
         schema = EmailAddress(whitelist=whitelisted_domains)
-        self.assertEqual(1, len(schema.whitelist))
+        self.assertEqual(1, len(schema.domain_whitelist))


### PR DESCRIPTION
STR:
Add the following test to `conformity/tests/test_fields_email.py` and run `pytest`:

```
    def test_whitelisted_address_via_constructor(self):
        whitelisted_domains = ['a-whitelisted-domain']
        schema = EmailAddress(whitelist=whitelisted_domains)
        self.assertEqual(
            schema.errors('a-name@a-whitelisted-domain'),
            [],
        )
```

Fails although Email field's init has it: `def __init__(self, message=None, code=None, whitelist=None)`. 

Also the constructor looks weird, instead of having the interface/expected parameters of `EmailAddress` has those defined at  `UnicodeString` as `attr.ib`:
```
ipdb> conformity.fields.email.EmailAddress()
EmailAddress(min_length=None, max_length=None, description=None, allow_blank=True)
```
This happens because `whitelist` is not marked as an `attr.ib` so the "attrs-built" constructor doesn't allows to specify it instantiating email address fields.

This PR fixes it, also removing not used nor needed code.