### PR TITLE
[MINOR] Enhance Dictionary field to permit ordered key documentation

### DIFF
--- a/conformity/fields/basic.py
+++ b/conformity/fields/basic.py
@@ -94,6 +94,7 @@ class Anything(Base):
         })
 
 
+@attr.s
 class Hashable(Anything):
     """
     Accepts any hashable value
@@ -146,7 +147,7 @@ class Integer(Base):
     """
 
     valid_type = six.integer_types
-    valid_noun = "integer"
+    valid_noun = "an integer"
     introspect_type = "integer"
 
     gt = attr.ib(default=None)
@@ -158,7 +159,7 @@ class Integer(Base):
     def errors(self, value):
         if not isinstance(value, self.valid_type) or isinstance(value, bool):
             return [
-                Error("Not a %s" % self.valid_noun),
+                Error("Not %s" % self.valid_noun),
             ]
         elif self.gt is not None and value <= self.gt:
             return [
@@ -188,23 +189,25 @@ class Integer(Base):
         })
 
 
+@attr.s
 class Float(Integer):
     """
     Accepts floating point numbers as well as integers.
     """
 
     valid_type = six.integer_types + (float,)
-    valid_noun = "float"
+    valid_noun = "a float"
     introspect_type = "float"
 
 
+@attr.s
 class Decimal(Integer):
     """
     Accepts arbitrary-precision Decimal number objects.
     """
 
     valid_type = decimal.Decimal
-    valid_noun = "decimal"
+    valid_noun = "a decimal"
     introspect_type = "decimal"
 
 
@@ -251,6 +254,7 @@ class UnicodeString(Base):
         })
 
 
+@attr.s
 class ByteString(UnicodeString):
     """
     Accepts only byte strings

--- a/conformity/fields/structures.py
+++ b/conformity/fields/structures.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import attr
+from collections import OrderedDict
 import six
 
 from conformity.error import (
@@ -85,6 +86,7 @@ class List(Base):
             self.get = lambda: index
 
 
+@attr.s
 class Set(List):
     valid_types = (set, frozenset)
     type_noun = "set"
@@ -98,7 +100,12 @@ class Set(List):
 
 class Dictionary(Base):
     """
-    A dictionary with types per key (and requirements per key).
+    A dictionary with types per key (and requirements per key). If the `contents` argument is an instance of
+    `OrderedDict`, the field introspection will include a `display_order` list of keys matching the order they exist
+    in the `OrderedDict`, and errors will be reported in the order the keys exist in the `OrderedDict`. Order will be
+    maintained for any calls to `extend` as long as those calls also use `OrderedDict`. Ordering behavior is undefined
+    otherwise. This field does NOT enforce that the value it validates presents keys in the same order. `OrderedDict`
+    is used strictly for documentation and error-object-ordering purposes only.
     """
 
     introspect_type = "dictionary"
@@ -185,15 +192,19 @@ class Dictionary(Base):
         """
         optional_keys = set(optional_keys or [])
         return Dictionary(
-            contents={
-                k: v for d in (self.contents, contents) for k, v in six.iteritems(d)
-            } if contents else self.contents,
+            contents=type(self.contents)(
+                (k, v) for d in (self.contents, contents) for k, v in six.iteritems(d)
+            ) if contents else self.contents,
             optional_keys=optional_keys if replace_optional_keys else self.optional_keys | optional_keys,
             allow_extra_keys=self.allow_extra_keys if allow_extra_keys is None else allow_extra_keys,
             description=self.description if description is None else description,
         )
 
     def introspect(self):
+        display_order = None
+        if isinstance(self.contents, OrderedDict):
+            display_order = list(self.contents.keys())
+
         return strip_none({
             "type": self.introspect_type,
             "contents": {
@@ -203,6 +214,7 @@ class Dictionary(Base):
             "optional_keys": list(self.optional_keys),
             "allow_extra_keys": self.allow_extra_keys,
             "description": self.description,
+            "display_order": display_order,
         })
 
 

--- a/conformity/fields/temporal.py
+++ b/conformity/fields/temporal.py
@@ -76,6 +76,7 @@ class TemporalBase(Base):
         })
 
 
+@attr.s
 class DateTime(TemporalBase):
     """
     Datetime instances
@@ -86,6 +87,7 @@ class DateTime(TemporalBase):
     introspect_type = "datetime"
 
 
+@attr.s
 class Date(TemporalBase):
     """
     Date instances
@@ -96,6 +98,7 @@ class Date(TemporalBase):
     introspect_type = "date"
 
 
+@attr.s
 class Time(TemporalBase):
     """
     Time instances
@@ -106,6 +109,7 @@ class Time(TemporalBase):
     introspect_type = "time"
 
 
+@attr.s
 class TimeDelta(TemporalBase):
     """
     Timedelta instances
@@ -116,6 +120,7 @@ class TimeDelta(TemporalBase):
     introspect_type = "timedelta"
 
 
+@attr.s
 class TZInfo(TemporalBase):
     """
     TZInfo instances


### PR DESCRIPTION
In dictionary validation, the order of the keys isn't important (and, indeed, can't be enforced when dealing with Msgpack, JSON, and others). However, the order that errors are presented (for display purposes) and the order the keys are defined (for documentation purposes) might be important. This enhancement makes the `Dictionary` field aware of ordered dictionary inputs, returns validation errors in that order, extends with that order kept in mind, and returns key ordering documentation with the field introspection.

Side note: This change also fixes a minor bug: Classes that inherit from `@attr.s`-decorated classes but don't define a constructor must also be decorated with `@attr.s` in order for IDE inspection to work properly.