### PR TITLE
Minor fixes to CountryCodeField

### DIFF
--- a/conformity/fields/country.py
+++ b/conformity/fields/country.py
@@ -1,20 +1,24 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import pycountry
 import six
 
-from conformity.error import ERROR_CODE_INVALID, Error
+from conformity.error import Error
 from conformity.fields.basic import Constant
-from conformity.utils import strip_none
 
-_countries_a2 = [c.alpha_2 for c in pycountry.countries]
+
+_countries_a2 = sorted(c.alpha_2 for c in pycountry.countries)
 
 
 class CountryCodeField(Constant):
     """
-        An enum field for restricting values to valid ISO 3166 country codes. Permits only current countries
-        and uses the ISO 3166 alpha-2 codes.
+    An enum field for restricting values to valid ISO 3166 country codes.
+    Permits only current countries and uses the ISO 3166 alpha-2 codes.
     """
+
     introspect_type = "country_code_field"
 
     def __init__(self, code_filter=lambda x: True, **kwargs):
@@ -24,20 +28,9 @@ class CountryCodeField(Constant):
         """
         valid_country_codes = (code for code in _countries_a2 if code_filter(code))
         super(CountryCodeField, self).__init__(*valid_country_codes, **kwargs)
+        self._error_message = "Not a valid country code"
 
     def errors(self, value):
         if not isinstance(value, six.text_type):
             return [Error("Not a unicode string")]
-
-        if value not in self.values:
-            return [Error(
-                "Not a valid country code",
-                code=ERROR_CODE_INVALID,
-                pointer="value",
-            )]
-
-    def introspect(self):
-        return strip_none({
-            "type": self.introspect_type,
-            "valid_country_codes": self.values,
-        })
+        return super(CountryCodeField, self).errors(value)

--- a/tests/test_fields_country.py
+++ b/tests/test_fields_country.py
@@ -1,14 +1,20 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
 
 import unittest
 
-from conformity.error import ERROR_CODE_INVALID
+from conformity.error import (
+    ERROR_CODE_INVALID,
+    ERROR_CODE_UNKNOWN,
+)
 from conformity.fields.country import CountryCodeField
 
 
 class CountryCodeTest(unittest.TestCase):
     """
-        Tests the CountryCodeField field
+    Tests the Country Code field.
     """
 
     def setUp(self):
@@ -16,31 +22,21 @@ class CountryCodeTest(unittest.TestCase):
         self.field = CountryCodeField()
 
     def test_valid(self):
-        self.assertEqual(self.field.errors(self.country), None)
+        self.assertEqual(self.field.errors(self.country), [])
 
     def test_invalid_country_code(self):
         country = 'USD'
         errors = self.field.errors(country)
         self.assertEqual(len(errors), 1)
-        error = errors[0]
-        self.assertEqual(
-            error.code,
-            ERROR_CODE_INVALID,
-        )
-        self.assertEqual(
-            error.message,
-            'Not a valid country code',
-        )
+        self.assertEqual(errors[0].code, ERROR_CODE_UNKNOWN)
+        self.assertEqual(errors[0].message, "Not a valid country code")
 
     def test_not_unicode_string(self):
         country = b'US'
         errors = self.field.errors(country)
         self.assertEqual(len(errors), 1)
-        error = errors[0]
-        self.assertEqual(
-            error.message,
-            'Not a unicode string',
-        )
+        self.assertEqual(errors[0].code, ERROR_CODE_INVALID)
+        self.assertEqual(errors[0].message, "Not a unicode string")
 
     def test_introspect(self):
         introspection = self.field.introspect()


### PR DESCRIPTION
Summary
- Fix: introspect() should return a `list` of 'values' instead of a `set`
- Fix: 'Not a valid country code' errors should not point to a non-existing pointer "value"
- Sort the list of valid codes returned by introspect()