### PR TITLE
[MINOR] Bump Attrs, drop Py3.4 support, add Tox+Docker for local tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,25 @@
+# from the repo
+.dockerignore
+.git
+.gitignore
+.travis.yml
+Dockerfile
+
+# Python + testing artifacts
+*.cover
+*.egg-info
+*.eggs
+*.log
+**/*.pyc
+**/*.pyd
+**/*.pyo
+.cache
+.coverage
+.pytest_cache
+.tox
+**/__pycache__
+coverage.xml
+pytests.xml
+
+# Random
+*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ __pycache__
 coverage.xml
 pytests.xml
 .pytest_cache
+.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ dist: xenial
 sudo: false
 python:
   - '2.7'
-  - '3.4'
   - '3.5'
   - '3.6'
   - '3.7'
@@ -11,7 +10,7 @@ install:
   - pip install -U pip setuptools flake8
 script:
   - flake8 .
-  - python setup.py test
+  - python setup.py test --addopts "--cov-report term-missing"
 jobs:
   include:
     - stage: deploy

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && \
+	apt-get install -y \
+		software-properties-common \
+		wget \
+		pkg-config \
+		lua5.1 \
+		liblua5.1-0-dev
+RUN add-apt-repository ppa:deadsnakes/ppa && \
+	apt-get update && \
+	apt-get install -y \
+		python2.7 \
+		python2.7-dev \
+		python3.4 \
+		python3.4-dev \
+		python3.5 \
+		python3.5-dev \
+		python3.6 \
+		python3.6-dev \
+		python3.7 \
+		python3.7-dev
+RUN wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py && \
+	python3.7 /tmp/get-pip.py && \
+	pip install tox
+
+WORKDIR /test/conformity
+
+CMD ["tox"]
+
+ADD . /test/conformity

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,15 +1,15 @@
 [bdist_wheel]
-universal=1
+python-tag=py27.py35.py36.py37
 
 [metadata]
 license_file = LICENSE
 
 [flake8]
-exclude = .git,.env/*,docs/*,build/*,.eggs/*,*.egg-info/*
+exclude = .git,.env/*,docs/*,build/*,.eggs/*,*.egg-info/*,.tox
 max-line-length = 120
 
 [aliases]
 test=pytest
 
 [tool:pytest]
-addopts = -s --junitxml=pytests.xml --cov-report xml --cov-report term-missing --cov=conformity.error --cov=conformity.utils --cov=conformity.validator --cov=conformity.fields
+addopts = -s --junitxml=pytests.xml  --cov-fail-under=85 --cov=conformity

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'six',
-        'attrs>=17.4,<19',
+        'attrs>=17.4,<20',
     ],
     tests_require=tests_require,
     setup_requires=['pytest-runner'],

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,32 @@
+[tox]
+envlist =
+    py{27,35,36}
+    py37-attrs{17,18,19}
+    py{27,37}-flake8
+    coverage
+
+[testenv]
+usedevelop=True
+deps =
+    .[testing]
+    attrs17: attrs~=17.4
+    attrs18: attrs~=18.2
+    attrs19: attrs~=19.1
+#    ipdb
+commands =
+    pytest --cov-append --cov-fail-under=1 --cov-report=
+
+[testenv:py27-flake8]
+skip_install = true
+deps = flake8
+commands = flake8
+
+[testenv:py37-flake8]
+skip_install = true
+deps = flake8
+commands = flake8
+
+[testenv:coverage]
+skip_install = true
+deps = coverage
+commands = coverage report -m --fail-under 85

--- a/tox.sh
+++ b/tox.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -ex
+
+docker build -t conformity-test .
+
+if [[ -z "$1" ]]
+then
+    docker run -it --rm conformity-test
+else
+    docker run -it --rm conformity-test tox "$@"
+fi


### PR DESCRIPTION
This commit does the following:

- Bumps Attrs to support all version 17.4 through 19.x
- Adds Tox+Docker to better test multiple combinations locally
- Drops support for Python 3.4