### PR TITLE
[MINOR] Support eager argument validation and type hints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ __pycache__
 coverage.xml
 pytests.xml
 .pytest_cache
+.mypy_cache
 .tox

--- a/conformity/error.py
+++ b/conformity/error.py
@@ -3,7 +3,15 @@ from __future__ import (
     unicode_literals,
 )
 
+from typing import Optional  # noqa: F401 TODO Python 3
+
 import attr
+import six  # noqa: F401 TODO Python 3
+
+from conformity.utils import (
+    attr_is_optional,
+    attr_is_string,
+)
 
 
 __all__ = (
@@ -24,6 +32,6 @@ class Error(object):
     """
     Represents an error found validating against the schema.
     """
-    message = attr.ib()
-    code = attr.ib(default=ERROR_CODE_INVALID)
-    pointer = attr.ib(default=None)
+    message = attr.ib(validator=attr_is_string())  # type: six.text_type
+    code = attr.ib(default=ERROR_CODE_INVALID, validator=attr_is_string())  # type: six.text_type
+    pointer = attr.ib(default=None, validator=attr_is_optional(attr_is_string()))  # type: Optional[six.text_type]

--- a/conformity/fields/basic.py
+++ b/conformity/fields/basic.py
@@ -4,6 +4,15 @@ from __future__ import (
 )
 
 import decimal
+from typing import (  # noqa: F401 TODO Python 3
+    Any,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+)
 
 import attr
 import six
@@ -12,7 +21,15 @@ from conformity.error import (
     ERROR_CODE_UNKNOWN,
     Error,
 )
-from conformity.utils import strip_none
+from conformity.utils import (
+    attr_is_bool,
+    attr_is_instance,
+    attr_is_int,
+    attr_is_number,
+    attr_is_optional,
+    attr_is_string,
+    strip_none,
+)
 
 
 @attr.s
@@ -21,34 +38,39 @@ class Base(object):
     Base field type.
     """
 
-    def errors(self, value):
+    def errors(self, value):  # type: (Any) -> List[Error]
         """
-        Returns a list of errors with the value. An empty/None return means
-        that it's valid.
+        Returns a list of errors with the value. An empty return means that it's valid.
         """
-        return [
-            Error('Validation not implemented on base type'),
-        ]
+        return [Error('Validation not implemented on base type')]
 
-    def introspect(self):
+    def introspect(self):  # type: () -> Dict[six.text_type, Any]
+        """
+        Returns a JSON-serializable dictionary containing introspection data that can be used to document the schema.
+        """
         raise NotImplementedError('You must override introspect() in a subclass')
+
+
+def attr_is_conformity_field():
+    return attr_is_instance(Base)
 
 
 class Constant(Base):
     """
-    Value that must match exactly. You can pass a series of options
-    and any will be accepted.
+    Value that must match exactly. You can pass a series of options and any will be accepted.
     """
 
     introspect_type = 'constant'
 
     def __init__(self, *args, **kwargs):
-        self.values = set(args)
+        self.values = frozenset(args)
         if not self.values:
-            raise TypeError('You must provide at least one constant value')
-        self.description = kwargs.get('description', None)
+            raise ValueError('You must provide at least one constant value')
+        self.description = kwargs.pop('description', None)  # type: Optional[six.text_type]
+        if self.description and not isinstance(self.description, six.text_type):
+            raise TypeError("'description' must be a unicode string")
         # Check they didn't pass any other kwargs
-        if list(kwargs.keys()) not in ([], ['description']):
+        if kwargs:
             raise TypeError('Invalid keyword arguments for Constant: {}'.format(kwargs.keys()))
 
         def _repr(cv):
@@ -60,22 +82,16 @@ class Constant(Base):
             self._error_message = 'Value is not one of: {}'.format(', '.join(sorted(_repr(v) for v in self.values)))
 
     def errors(self, value):
-        """
-        Returns a list of errors with the value. An empty/None return means
-        that it's valid.
-        """
         if value not in self.values:
             return [Error(self._error_message, code=ERROR_CODE_UNKNOWN)]
         return []
 
     def introspect(self):
-        result = {
+        return strip_none({
             'type': self.introspect_type,
-            'values': list(self.values),
-        }
-        if self.description is not None:
-            result['description'] = self.description
-        return result
+            'values': sorted(self.values),
+            'description': self.description,
+        })
 
 
 @attr.s
@@ -85,10 +101,11 @@ class Anything(Base):
     """
 
     introspect_type = 'anything'
-    description = attr.ib(default=None)
+
+    description = attr.ib(default=None, validator=attr_is_optional(attr_is_string()))  # type: Optional[six.text_type]
 
     def errors(self, value):
-        pass
+        return []
 
     def introspect(self):
         return strip_none({
@@ -112,6 +129,7 @@ class Hashable(Anything):
             return [
                 Error('Value is not hashable'),
             ]
+        return []
 
     def introspect(self):
         return strip_none({
@@ -128,13 +146,14 @@ class Boolean(Base):
 
     introspect_type = 'boolean'
 
-    description = attr.ib(default=None)
+    description = attr.ib(default=None, validator=attr_is_optional(attr_is_string()))  # type: Optional[six.text_type]
 
     def errors(self, value):
         if not isinstance(value, bool):
             return [
                 Error('Not a boolean'),
             ]
+        return []
 
     def introspect(self):
         return strip_none({
@@ -149,37 +168,42 @@ class Integer(Base):
     Accepts valid integers, with optional range limits.
     """
 
-    valid_type = six.integer_types
-    valid_noun = 'an integer'
-    introspect_type = 'integer'
+    valid_type = six.integer_types  # type: Union[Type, Tuple[Type, ...]]
+    valid_noun = 'an integer'  # type: six.text_type
+    introspect_type = 'integer'  # type: six.text_type
 
-    gt = attr.ib(default=None)
-    gte = attr.ib(default=None)
-    lt = attr.ib(default=None)
-    lte = attr.ib(default=None)
-    description = attr.ib(default=None)
+    gt = attr.ib(
+        default=None,
+        validator=attr_is_optional(attr_is_number()),
+    )  # type: Optional[Union[int, float, decimal.Decimal]]
+    gte = attr.ib(
+        default=None,
+        validator=attr_is_optional(attr_is_number()),
+    )  # type: Optional[Union[int, float, decimal.Decimal]]
+    lt = attr.ib(
+        default=None,
+        validator=attr_is_optional(attr_is_number()),
+    )  # type: Optional[Union[int, float, decimal.Decimal]]
+    lte = attr.ib(
+        default=None,
+        validator=attr_is_optional(attr_is_number()),
+    )  # type: Optional[Union[int, float, decimal.Decimal]]
+    description = attr.ib(default=None, validator=attr_is_optional(attr_is_string()))  # type: Optional[six.text_type]
 
     def errors(self, value):
         if not isinstance(value, self.valid_type) or isinstance(value, bool):
-            return [
-                Error('Not %s' % self.valid_noun),
-            ]
-        elif self.gt is not None and value <= self.gt:
-            return [
-                Error('Value not > %s' % self.gt),
-            ]
-        elif self.lt is not None and value >= self.lt:
-            return [
-                Error('Value not < %s' % self.lt),
-            ]
-        elif self.gte is not None and value < self.gte:
-            return [
-                Error('Value not >= %s' % self.gte),
-            ]
-        elif self.lte is not None and value > self.lte:
-            return [
-                Error('Value not <= %s' % self.lte),
-            ]
+            return [Error('Not {}'.format(self.valid_noun))]
+
+        errors = []
+        if self.gt is not None and value <= self.gt:
+            errors.append(Error('Value not > {}'.format(self.gt)))
+        if self.lt is not None and value >= self.lt:
+            errors.append(Error('Value not < {}'.format(self.lt)))
+        if self.gte is not None and value < self.gte:
+            errors.append(Error('Value not >= {}'.format(self.gte)))
+        if self.lte is not None and value > self.lte:
+            errors.append(Error('Value not <= {}'.format(self.lte)))
+        return errors
 
     def introspect(self):
         return strip_none({
@@ -198,7 +222,7 @@ class Float(Integer):
     Accepts floating point numbers as well as integers.
     """
 
-    valid_type = six.integer_types + (float,)
+    valid_type = six.integer_types + (float,)  # type: ignore # see https://github.com/python/mypy/issues/224
     valid_noun = 'a float'
     introspect_type = 'float'
 
@@ -220,32 +244,29 @@ class UnicodeString(Base):
     Accepts only unicode strings
     """
 
-    valid_type = six.text_type
+    valid_type = six.text_type  # type: Type
     valid_noun = 'unicode string'
     introspect_type = 'unicode'
 
-    min_length = attr.ib(default=None)
-    max_length = attr.ib(default=None)
-    description = attr.ib(default=None)
-    allow_blank = attr.ib(default=True, type=bool)
+    min_length = attr.ib(default=None, validator=attr_is_optional(attr_is_int()))  # type: Optional[int]
+    max_length = attr.ib(default=None, validator=attr_is_optional(attr_is_int()))  # type: Optional[int]
+    description = attr.ib(default=None, validator=attr_is_optional(attr_is_string()))  # type: Optional[six.text_type]
+    allow_blank = attr.ib(default=True, validator=attr_is_bool())  # type: bool
+
+    def __attrs_post_init__(self):
+        if self.min_length is not None and self.max_length is not None and self.min_length > self.max_length:
+            raise ValueError('min_length cannot be greater than max_length in UnicodeString')
 
     def errors(self, value):
         if not isinstance(value, self.valid_type):
-            return [
-                Error('Not a %s' % self.valid_noun),
-            ]
+            return [Error('Not a {}'.format(self.valid_noun))]
         elif self.min_length is not None and len(value) < self.min_length:
-            return [
-                Error('String must have a length of at least %s' % self.min_length),
-            ]
+            return [Error('String must have a length of at least {}'.format(self.min_length))]
         elif self.max_length is not None and len(value) > self.max_length:
-            return [
-                Error('String must have a length no more than %s' % self.max_length),
-            ]
+            return [Error('String must have a length no more than {}'.format(self.max_length))]
         elif not (self.allow_blank or value.strip()):
-            return [
-                Error('String cannot be blank'),
-            ]
+            return [Error('String cannot be blank')]
+        return []
 
     def introspect(self):
         return strip_none({
@@ -275,7 +296,8 @@ class UnicodeDecimal(Base):
     """
 
     introspect_type = 'unicode_decimal'
-    description = attr.ib(default=None)
+
+    description = attr.ib(default=None, validator=attr_is_optional(attr_is_string()))  # type: Optional[six.text_type]
 
     def errors(self, value):
         if not isinstance(value, six.text_type):

--- a/conformity/fields/country.py
+++ b/conformity/fields/country.py
@@ -3,6 +3,11 @@ from __future__ import (
     unicode_literals,
 )
 
+from typing import (  # noqa: F401 TODO Python 3
+    AnyStr,
+    Callable,
+)
+
 import pycountry
 import six
 
@@ -26,11 +31,17 @@ class CountryCodeField(Constant):
 
     introspect_type = 'country_code_field'
 
-    def __init__(self, code_filter=lambda x: True, **kwargs):
+    def __init__(
+        self,
+        code_filter=lambda x: True,  # type: Callable[[AnyStr], bool]
+        **kwargs
+    ):
         """
         :param code_filter: If specified, will be called to further filter the available country codes
         :type code_filter: lambda x: bool
         """
+        if not callable(code_filter):
+            raise TypeError('Argument code_filter must be a callable that accepts a country code and returns a bool')
         valid_country_codes = (code for code in _countries_a2 if code_filter(code))
         super(CountryCodeField, self).__init__(*valid_country_codes, **kwargs)
         self._error_message = 'Not a valid country code'

--- a/conformity/utils.py
+++ b/conformity/utils.py
@@ -3,11 +3,115 @@ from __future__ import (
     unicode_literals,
 )
 
+import decimal
+from typing import Dict  # noqa: F401 TODO Python 3
 
-def strip_none(value):
+import attr
+import six
+
+
+def strip_none(value):  # type: (Dict) -> Dict
     """
-    Takes a dict and removes all keys that have None values, used mainly for
-    tidying up introspection responses. Take care not to use this on something
-    that might legitimately contain a None.
+    Takes a dict and removes all keys that have `None` values, used mainly for tidying up introspection responses. Take
+    care not to use this on something that might legitimately contain a `None`.
     """
     return {k: v for k, v in value.items() if v is not None}
+
+
+attr_is_instance = attr.validators.instance_of
+attr_is_optional = attr.validators.optional
+
+
+def attr_is_bool():
+    return attr_is_instance(bool)
+
+
+def attr_is_int():
+    return attr_is_instance(int)
+
+
+def attr_is_number():
+    return attr_is_instance((int, float, decimal.Decimal))
+
+
+def attr_is_set():
+    return attr_is_instance((set, frozenset))
+
+
+def attr_is_string():
+    return attr_is_instance(six.text_type)
+
+
+# In Attrs 19.1.0 we can use attr.validators.deep_iterable, but we want to support older versions for a while longer,
+# so we use this custom validator for now
+def attr_is_iterable(member_validator=None, iterable_validator=None):
+    # noinspection PyShadowingNames
+    def validator(inst, attr, value):
+        if not hasattr(value, '__iter__'):
+            raise TypeError(
+                "'{name}' must be iterable (got {value!r} that is a {actual!r}).".format(
+                    name=attr.name,
+                    actual=value.__class__,
+                    value=value,
+                ),
+                attr,
+                value,
+            )
+
+        if iterable_validator:
+            iterable_validator(inst, attr, value)
+
+        class A(object):
+            def __init__(self, num):
+                self.num = num
+
+            @property
+            def name(self):
+                return '{}.{}'.format(attr.name, self.num)
+
+        for i, item in enumerate(value):
+            member_validator(inst, A(i), item)
+
+    return validator
+
+
+def attr_is_instance_or_instance_tuple(check_type):
+    # first, some meta META validation
+    if not isinstance(check_type, type):
+        if not isinstance(check_type, tuple):
+            raise TypeError("'check_type' must be a type or tuple of types")
+        for i, t in enumerate(check_type):
+            if not isinstance(t, type):
+                raise TypeError("'check_type[{i}] must be a type or tuple of types".format(i=i))
+
+    def validator(_instance, attribute, value):
+        if isinstance(value, check_type):
+            return
+
+        if not isinstance(value, tuple):
+            raise TypeError(
+                "'{name}' must be a {t!r} or a tuple of {t!r} (got {value!r} that is a {actual!r}).".format(
+                    name=attribute.name,
+                    actual=type(value),
+                    value=value,
+                    t=check_type,
+                ),
+                attribute,
+                value,
+            )
+
+        for i, item in enumerate(value):
+            if not isinstance(item, check_type):
+                raise TypeError(
+                    "'{name}[{i}]' must be a {t!r} (got {value!r} that is a {actual!r}).".format(
+                        i=i,
+                        name=attribute.name,
+                        actual=type(item),
+                        value=item,
+                        t=check_type,
+                    ),
+                    attribute,
+                    item,
+                )
+
+    return validator

--- a/conformity/validator.py
+++ b/conformity/validator.py
@@ -54,10 +54,10 @@ def validate(schema, value, noun='value'):
         error_details = ''
         for error in errors:
             if error.pointer:
-                error_details += '  - %s: %s\n' % (error.pointer, error.message)
+                error_details += '  - {}: {}\n'.format(error.pointer, error.message)
             else:
-                error_details += '  - %s\n' % error.message
-        raise ValidationError('Invalid %s:\n%s' % (noun, error_details))
+                error_details += '  - {}\n'.format(error.message)
+        raise ValidationError('Invalid {}:\n{}'.format(noun, error_details))
 
 
 def validate_call(

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,21 @@ known_third_party=attr,currint,dateutil,freezegun,py,pycountry,pytest,pytz,six
 known_current_project=conformity
 known_tests=tests
 
+[mypy]
+python_version = 2.7
+[mypy-setup]
+ignore_errors = True
+[mypy-tasks]
+ignore_errors = True
+[mypy-currint.*]
+ignore_missing_imports = True
+[mypy-freezegun.*]
+ignore_missing_imports = True
+[mypy-pycountry.*]
+ignore_missing_imports = True
+[mypy-pytest.*]
+ignore_missing_imports = True
+
 [aliases]
 test=pytest
 

--- a/tests/test_fields_country.py
+++ b/tests/test_fields_country.py
@@ -5,6 +5,8 @@ from __future__ import (
 
 import unittest
 
+import pytest
+
 from conformity.error import (
     ERROR_CODE_INVALID,
     ERROR_CODE_UNKNOWN,
@@ -20,6 +22,11 @@ class CountryCodeTest(unittest.TestCase):
     def setUp(self):
         self.country = 'US'
         self.field = CountryCodeField()
+
+    def test_constructor(self):
+        with pytest.raises(TypeError):
+            # noinspection PyTypeChecker
+            CountryCodeField(code_filter='not a callable')
 
     def test_valid(self):
         self.assertEqual(self.field.errors(self.country), [])

--- a/tests/test_fields_currency.py
+++ b/tests/test_fields_currency.py
@@ -9,6 +9,7 @@ from currint import (
     Amount,
     Currency,
 )
+import pytest
 
 from conformity.error import (
     ERROR_CODE_INVALID,
@@ -30,6 +31,19 @@ class AmountFieldTests(unittest.TestCase):
         self.field = currency_fields.Amount(
             description='An amount',
         )
+
+    def test_constructor(self):
+        with pytest.raises(TypeError):
+            # noinspection PyTypeChecker
+            currency_fields.Amount(valid_currencies=1234)  # not iterable
+
+        with pytest.raises(TypeError):
+            # noinspection PyTypeChecker
+            currency_fields.Amount(valid_currencies=['1', '2', '3'])  # not a set
+
+        with pytest.raises(TypeError):
+            # noinspection PyTypeChecker
+            currency_fields.Amount(valid_currencies={1, 2, 3})  # not strings
 
     def test_valid(self):
         self.assertEqual(self.field.errors(self.value), [])
@@ -171,6 +185,31 @@ class AmountDictionaryFieldTests(unittest.TestCase):
             description='An amount',
             valid_currencies=['JPY', 'USD'],
         )
+
+    def test_constructor(self):
+        with pytest.raises(TypeError):
+            # noinspection PyTypeChecker
+            currency_fields.AmountDictionary(valid_currencies=1234)
+
+        with pytest.raises(TypeError):
+            # noinspection PyTypeChecker
+            currency_fields.AmountDictionary(valid_currencies=[1, 2, 3, 4])
+
+        with pytest.raises(TypeError):
+            # noinspection PyTypeChecker
+            currency_fields.AmountDictionary(gt='not an int')
+
+        with pytest.raises(TypeError):
+            # noinspection PyTypeChecker
+            currency_fields.AmountDictionary(gte='not an int')
+
+        with pytest.raises(TypeError):
+            # noinspection PyTypeChecker
+            currency_fields.AmountDictionary(lt='not an int')
+
+        with pytest.raises(TypeError):
+            # noinspection PyTypeChecker
+            currency_fields.AmountDictionary(lte='not an int')
 
     def test_valid(self):
         self.assertEqual(self.field.errors(self.value), [])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,38 @@
+from __future__ import absolute_import, unicode_literals
+
+import attr
+import pytest
+import six
+
+from conformity.utils import attr_is_instance_or_instance_tuple
+
+
+class TestAttrIsInstanceOrInstanceTuple(object):
+    def test_bad_argument(self):
+        with pytest.raises(TypeError):
+            attr_is_instance_or_instance_tuple('not a type')
+
+        with pytest.raises(TypeError):
+            attr_is_instance_or_instance_tuple((int, 'also not a type'))
+
+    def test_validator(self):
+        @attr.s
+        class ForTest(object):
+            foo = attr.ib(default=1, validator=attr_is_instance_or_instance_tuple(int))
+            bar = attr.ib(
+                default='hello',
+                validator=attr_is_instance_or_instance_tuple((six.text_type, six.binary_type)),
+            )
+
+        ForTest()
+        ForTest(foo=18378)
+        ForTest(foo=(17267, 19378))
+        ForTest(bar='yep')
+        ForTest(bar=b'also yep')
+        ForTest(bar=('baz', b'qux'))
+
+        with pytest.raises(TypeError):
+            ForTest(foo=3.14)
+
+        with pytest.raises(TypeError):
+            ForTest(bar=18378)

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -67,7 +67,7 @@ class ValidatorTests(unittest.TestCase):
             # Special case to check return value stuff
             if name == 'error':
                 return 5
-            return '%s, %s!' % (greeting, name)
+            return '{}, {}!'.format(greeting, name)
 
         self.assertEqual(greeter(name='Andrew'), 'Hello, Andrew!')
         self.assertEqual(greeter(name='Andrew', greeting='Ahoy'), 'Ahoy, Andrew!')
@@ -135,7 +135,7 @@ class ValidatorTests(unittest.TestCase):
                 # Special case to check return value stuff
                 if name == 'error':
                     return 5
-                return '%s, %s!' % (greeting, name)
+                return '{}, {}!'.format(greeting, name)
 
             @staticmethod
             @validate_call(args=Tuple(Integer(), Integer()), kwargs=None, returns=Integer())


### PR DESCRIPTION
- Add exhaustive validation to all Conformity field arguments to avoid weird errors at runtime when Conformity fields are used incorrectly.
- Add Python type hints throughout the Conformity API to make using Conformity fields easier with type-smart IDEs.
- Write a bunch more tests to increase code coverage from 92% to 99%.
- Standardize on `.format` instead of `%` (previously this was inconsistent).
- Refactor `Dictionary` to be an `attr.s` class now (fully backwards-compatible, all features still work).