### PR TITLE
[PATCH] Regression: Fix Dictionary subclass processing and validation

### DIFF
--- a/conformity/fields/structures.py
+++ b/conformity/fields/structures.py
@@ -141,29 +141,38 @@ class Dictionary(Base):
     description = attr.ib(default=None, validator=attr_is_optional(attr_is_string()))  # type: Optional[six.text_type]
 
     def __attrs_post_init__(self):
-        if self.contents is None and getattr(self.__class__, 'contents', None):
+        if self.contents is None and getattr(self.__class__, 'contents', None) is not None:
             # If no contents were provided but a subclass has hard-coded contents, use those
             self.contents = self.__class__.contents
         if self.contents is None:
             # If there are still no contents, raise an error
             raise ValueError("'contents' is a required argument")
+        if not isinstance(self.contents, dict):
+            raise TypeError("'contents' must be a dict")
 
-        if self.optional_keys is self._optional_keys_default and getattr(self.__class__, 'optional_keys', None):
+        if (
+            self.optional_keys is self._optional_keys_default and
+            getattr(self.__class__, 'optional_keys', None) is not None
+        ):
             # If the optional_keys argument was defaulted (not specified) but a subclass has it hard-coded, use that
             self.optional_keys = self.__class__.optional_keys
         if not isinstance(self.optional_keys, frozenset):
             self.optional_keys = frozenset(self.optional_keys)
 
-        if self.allow_extra_keys is None and getattr(self.__class__, 'allow_extra_keys', None):
+        if self.allow_extra_keys is None and getattr(self.__class__, 'allow_extra_keys', None) is not None:
             # If the allow_extra_keys argument was not specified but a subclass has it hard-coded, use that value
             self.allow_extra_keys = self.__class__.allow_extra_keys
         if self.allow_extra_keys is None:
             # If no value is found, default to False
             self.allow_extra_keys = False
+        if not isinstance(self.allow_extra_keys, bool):
+            raise TypeError("'allow_extra_keys' must be a boolean")
 
         if self.description is None and getattr(self.__class__, 'description', None):
             # If the description was not specified but a subclass has it hard-coded, use that value
             self.description = self.__class__.description
+        if self.description is not None and not isinstance(self.description, six.text_type):
+            raise TypeError("'description' must be a unicode string")
 
     def errors(self, value):
         if not isinstance(value, dict):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -6,6 +6,10 @@ from __future__ import (
 from collections import OrderedDict
 import datetime
 import decimal
+from typing import (  # noqa: F401 TODO Python 3
+    Hashable as HashableType,
+    Tuple as TupleType,
+)
 import unittest
 
 import freezegun
@@ -633,6 +637,37 @@ class FieldTests(unittest.TestCase):
         with pytest.raises(TypeError):
             # noinspection PyTypeChecker
             Another({'foo': UnicodeString()}, optional_keys=1234)  # type: ignore
+
+        class BadDict1(Dictionary):
+            allow_extra_keys = 'not a bool'  # type: ignore
+
+        with pytest.raises(TypeError):
+            BadDict1(contents={})
+
+        class BadDict2(Dictionary):
+            description = b'not a unicode'  # type: ignore
+
+        with pytest.raises(TypeError):
+            BadDict2(contents={})
+
+        class BadDict3(Dictionary):
+            contents = 'not a dict'  # type: ignore
+
+        with pytest.raises(TypeError):
+            BadDict3()
+
+        class ExtraDict(Dictionary):
+            contents = {}  # type: ignore
+            optional_keys = ('one', 'two')  # type: TupleType[HashableType, ...]
+
+        d = ExtraDict()
+        assert d.optional_keys == frozenset({'one', 'two'})
+
+        class ExtraExtraDict(ExtraDict):
+            optional_keys = ()  # type: TupleType[HashableType, ...]
+
+        d = ExtraExtraDict()
+        assert d.optional_keys == frozenset({})
 
     def test_decimal(self):  # type: () -> None
         """


### PR DESCRIPTION
When `Dictionary` is subclassed, the subclass should be able to specify empty `contents` and `optional_keys`. Additionally, subclassed `contents`, `allow_extra_keys`, and `description`, if specified, should be validated to be the proper type.