### PR TITLE
[MINOR] Add PythonPath field, superclass of TypePath

### DIFF
--- a/conformity/fields/__init__.py
+++ b/conformity/fields/__init__.py
@@ -30,6 +30,7 @@ from conformity.fields.meta import (
     Nullable,
     ObjectInstance,
     Polymorph,
+    PythonPath,
     TypePath,
     TypeReference,
 )
@@ -82,6 +83,7 @@ __all__ = (
     'Nullable',
     'ObjectInstance',
     'Polymorph',
+    'PythonPath',
     'SchemalessDictionary',
     'Set',
     'Time',


### PR DESCRIPTION
Add a new `PythonPath` field to support checking the importability (and schema) of any Python item, and make it the superclass of `TypePath`.