### PR TITLE
[MINOR] Implement #65: Add support for generic Settings objects

### DIFF
--- a/conformity/fields/structures.py
+++ b/conformity/fields/structures.py
@@ -6,6 +6,7 @@ from __future__ import (
 from collections import OrderedDict
 from typing import (  # noqa: F401 TODO Python 3
     Any as AnyType,
+    Dict,
     FrozenSet,
     Hashable as HashableType,
     Mapping,
@@ -14,6 +15,7 @@ from typing import (  # noqa: F401 TODO Python 3
     Tuple as TupleType,
     Type,
     Union,
+    cast,
 )
 
 import attr
@@ -205,12 +207,13 @@ class Dictionary(Base):
 
     def extend(
         self,
-        contents=None,
-        optional_keys=None,
-        allow_extra_keys=None,
-        description=None,
-        replace_optional_keys=False,
+        contents=None,  # type: Optional[Mapping[HashableType, Base]]
+        optional_keys=None,  # type: Optional[Union[TupleType[HashableType, ...], FrozenSet[HashableType]]]
+        allow_extra_keys=None,  # type: Optional[bool]
+        description=None,  # type: Optional[six.text_type]
+        replace_optional_keys=False,  # type: bool
     ):
+        # type: (...) -> Dictionary
         """
         This method allows you to create a new `Dictionary` that extends the current `Dictionary` with additional
         contents and/or optional keys, and/or replaces the `allow_extra_keys` and/or `description` attributes.
@@ -230,12 +233,12 @@ class Dictionary(Base):
         :return: A new `Dictionary` extended from the current `Dictionary` based on the supplied arguments
         :rtype: Dictionary
         """
-        optional_keys = set(optional_keys or [])
+        optional_keys = frozenset(optional_keys or ())
         return Dictionary(
-            contents=type(self.contents)(
+            contents=cast(Type[Union[Dict, OrderedDict]], type(self.contents))(
                 (k, v) for d in (self.contents, contents) for k, v in six.iteritems(d)
             ) if contents else self.contents,
-            optional_keys=optional_keys if replace_optional_keys else self.optional_keys | optional_keys,
+            optional_keys=optional_keys if replace_optional_keys else frozenset(self.optional_keys) | optional_keys,
             allow_extra_keys=self.allow_extra_keys if allow_extra_keys is None else allow_extra_keys,
             description=self.description if description is None else description,
         )

--- a/conformity/settings/__init__.py
+++ b/conformity/settings/__init__.py
@@ -1,0 +1,381 @@
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
+
+import copy
+import itertools
+from typing import (  # noqa: F401 TODO Python 3
+    Any,
+    Dict,
+    ItemsView,
+    Iterable,
+    Iterator,
+    KeysView,
+    List,
+    Mapping,
+    Optional,
+    Tuple,
+    TypeVar,
+    ValuesView,
+    cast,
+)
+
+import six
+
+from conformity import fields
+from conformity.error import ValidationError
+from conformity.validator import validate
+
+
+__all__ = (
+    'Settings',
+    'SettingsData',
+    'SettingsItemsView',
+    'SettingsKeysView',
+    'SettingsSchema',
+    'SettingsValuesView',
+)
+
+
+try:
+    # TODO Always use ABCMeta when Python 3.7-only
+    from typing import GenericMeta as BaseMeta  # type: ignore
+except ImportError:
+    from abc import ABCMeta as BaseMeta  # type: ignore
+
+
+if six.PY2:
+    # TODO Always use KeysView, ValuesView, and ItemsView when Python 3-only
+    SettingsKeysView = List[six.text_type]
+    SettingsValuesView = List[Any]
+    SettingsItemsView = List[Tuple[six.text_type, Any]]
+else:
+    SettingsKeysView = KeysView[six.text_type]
+    SettingsValuesView = ValuesView[Any]
+    SettingsItemsView = ItemsView[six.text_type, Any]
+
+
+SettingsSchema = Mapping[six.text_type, fields.Base]
+SettingsData = Mapping[six.text_type, Any]
+
+# noinspection PyShadowingBuiltins
+_VT = TypeVar('_VT', bound=Any)
+
+
+class _SettingsMetaclass(BaseMeta):
+    """
+    Metaclass that gathers fields defined on settings objects into a single variable to access them, and does so at
+    the time the class is defined instead of when it is constructed, which makes this perform considerably better.
+    """
+
+    ###################################################################################################################
+    #
+    # Development Notes:
+    #
+    # _SettingsMetaclass has to extend BaseMeta to prevent this error:
+    #
+    #    TypeError: metaclass conflict: the metaclass of a derived class must be a (non-strict) subclass of the
+    #    metaclasses of all its bases
+    #
+    # Mapping introduces six classes into the hierarchy: Mapping, Collection, Sized, Iterable, Generic, and Container.
+    # In Python 3.7+, all of these have a metaclass of ABCMeta, so we can use that. In Python 2.7-3.6, most have a
+    # metaclass of ABCMeta, but Generic has a metaclass of GenericMeta (which does not exist in Python 3.7+), which
+    # extends ABCMeta. So we extend from GenericMeta in Python 2.7-3.6 and ABCMeta in Python 3.7+, which gets us a
+    # metaclass that is a subclass of the metaclasses of all of the bases of Settings. Observe (abbreviated output
+    # from ipython2/ipython3):
+    #
+    # class Meta(BaseMeta):
+    #     def __new__(mcs, name, bases, body):
+    #         print('{}: {}'.format(name, bases))
+    #         return super(Meta, mcs).__new__(mcs, name, bases, body)
+    #
+    # @six.add_metaclass(Meta)
+    # class Base(Mapping[six.text_type, Any]):
+    #     pass
+    #
+    # class Foo(Base):
+    #     pass
+    # > Foo: (<class '__main__.Base'>,)
+    #
+    # class Bar(Base):
+    #     pass
+    # > Bar: (<class '__main__.Base'>,)
+    #
+    # class Baz(Base):
+    #     pass
+    # > Baz: (<class '__main__.Base'>,)
+    #
+    # class Qux(Foo, Bar):
+    #     pass
+    # > Qux: (<class '__main__.Foo'>, <class '__main__.Bar'>)
+    #
+    # class Qux(Foo, Bar, Baz):
+    #     pass
+    # > Qux: (<class '__main__.Foo'>, <class '__main__.Bar'>, <class '__main__.Baz'>)
+    #
+    ###################################################################################################################
+
+    def __new__(mcs, name, bases, body):
+        cls = super(_SettingsMetaclass, mcs).__new__(mcs, name, bases, body)
+
+        # Merge the schema and defaults objects with their parents
+        if cls.__name__ != 'Settings' or cls.__module__ != _SettingsMetaclass.__module__:
+            if not issubclass(cls, Settings):
+                raise TypeError('The internal _SettingsMetaclass is only valid on Settings')
+
+            applicable_bases = [b for b in bases if issubclass(b, Settings)]
+
+            # We chain all the schemas and defaults from the applicable bases, and then finally end with schema and
+            # defaults from the being-defined class if and only if they are not directly inherited from a base. We
+            # reverse the bases because we want a left-er base's schema and defaults to take precedence over its
+            # right-er bases' schemas and defaults, in the same way left-er bases' method definitions in Python take
+            # precedence over their right-er bases' method definitions.
+            schema_not_inherited = not any(cls.schema is b.schema for b in applicable_bases)
+            defaults_not_inherited = not any(cls.defaults is b.defaults for b in applicable_bases)
+            chain_of_schemas = itertools.chain(
+                itertools.chain(*(b.schema.items() for b in reversed(applicable_bases))),
+                cast(Iterable[Tuple[six.text_type, fields.Base]], cls.schema.items() if schema_not_inherited else ()),
+            )
+            chain_of_defaults = itertools.chain(
+                itertools.chain(*(b.defaults.items() for b in reversed(applicable_bases))),
+                cast(Iterable[Tuple[six.text_type, Any]], cls.defaults.items() if defaults_not_inherited else ()),
+            )
+
+            # Now we define the schema and defaults for this class to be the merged schemas and defaults from above.
+            cls.schema = dict(chain_of_schemas)
+            cls.defaults = dict(chain_of_defaults)
+
+        return cls
+
+
+@six.add_metaclass(_SettingsMetaclass)
+class Settings(Mapping[six.text_type, Any]):
+    """
+    Represents settings schemas and defaults that can be inherited and merged across the inheritance hierarchy.
+
+    The base classes are designed to be inherited from and have their schema extended, any number of levels deep.
+    Multiple inheritance is also supported, with the rightmost `Settings`-extending base class's schema and defaults
+    taking precedence over all following `Settings`-extending base classes to the right, and so on. Schema and defaults
+    from all base classes will be merged, with left-er base classes overriding conflicting right-er base classes'
+    schema or defaults components, and then finally the concrete class's schema and settings (if any) will be merged
+    in, overriding conflicting base classes' schema or defaults components. This matches the behavior of Python method
+    definition inheritance.
+
+    Examples:
+        class BaseSettings(Settings):
+            schema = {
+                'foo': fields.Integer(),
+                'bar': fields.Dictionary({'baz': fields.Integer(), 'qux': fields.Boolean}),
+            }  # type: SettingsSchema
+
+            defaults = {
+                'foo': 1,
+                'bar': {'baz': 2},
+            }  # type: SettingsData
+
+        class MoreBaseSettings(BaseSettings):
+            # `schema` will have 'foo' and 'ipsum' from this class, 'bar' from `BaseSettings`
+            schema = {
+                'foo': fields.Any(fields.Integer(), fields.Float(), fields.Decimal()),
+                'ipsum': fields.UnicodeString(),
+            }  # type: SettingsSchema
+
+            # `defaults` will have 'ipsum' from this class, 'foo' and 'bar' from `BaseSettings`
+            defaults = {
+                'ipsum': 'Default more',
+            }
+
+        class OtherBaseSettings(Settings):
+            schema = {
+                'lorem': fields.UnicodeString(),
+                'ipsum': fields.ByteString(),
+            }  # type: SettingsSchema
+
+            defaults = {
+                'lorem': 'Default lorem',
+            }  # type: SettingsData
+
+        class FinalSettings1(BaseSettings, OtherBaseSettings):
+            # `schema` will have 'foo', 'bar', 'lorem', and 'ipsum'
+            # `defaults` will have 'foo', 'bar', and 'lorem'
+            pass
+
+        class FinalSettings2(OtherBaseSettings, MoreBaseSettings):
+            # `schema` will have 'lorem', 'ipsum' from `OtherBaseSettings`, 'foo' from `MoreBaseSettings`, 'bar'
+            # `defaults` will have 'lorem', 'ipsum', 'foo', 'bar'
+            pass
+
+        class FinalSettings3(MoreBaseSettings, OtherBaseSettings):
+            # `schema` will have 'foo', 'ipsum' from `MoreBaseSettings`, 'lorem' from `OtherBaseSettings`, 'bar'
+            # `defaults` will have 'lorem', 'ipsum', 'foo', 'bar'
+            pass
+
+    To use `Settings`, instantiate the target/concrete `Settings` subclass with the raw settings value (a `Mapping`,
+    usually a dictionary), which will validate that data according to the schema, and then access the data using
+    `Mapping` syntax and methods, such as `settings['foo']`, `settings.get('foo')`, `'foo' in settings`, etc. The class
+    will merge any passed values into its defaults, with passed values taking precedence over defaults when conflicts
+    arise, before performing validation.
+    """
+
+    schema = {}  # type: SettingsSchema
+    defaults = {}  # type: SettingsData
+
+    class ImproperlyConfigured(Exception):
+        """
+        Raised when validation fails for the configuration data (contents) passed into the constructor or `set(data)`.
+        """
+
+    def __init__(self, data):  # type: (SettingsData) -> None
+        """
+        Instantiate a new Settings object and validate its contents.
+
+        :param data: A mapping of unicode string keys to any values, which, together with the defined defaults in this
+                     class, should match the defined schema for this class, as merged with its parent classes.
+        """
+        self._data = {}  # type: SettingsData
+        self.set(data)
+
+    def set(self, data):  # type: (SettingsData) -> None
+        """
+        Initialize and validate the configuration data (contents) for this settings object.
+
+        :param data: A mapping of unicode string keys to any values, which, together with the defined defaults in this
+                     class, should match the defined schema for this class, as merged with its parent classes.
+        """
+        # Merged the class defaults with the supplied data to get the effective settings data
+        settings = self._merge_mappings(copy.deepcopy(data), copy.deepcopy(self.defaults))
+
+        # Ensure that all keys required by the schema are present in the settings data
+        unpopulated_keys = set(self.schema.keys()) - set(settings.keys())
+        if unpopulated_keys:
+            raise self.ImproperlyConfigured(
+                'No value provided for required setting(s): {}'.format(', '.join(unpopulated_keys))
+            )
+
+        # Ensure that all keys in the settings data are present in the schema
+        unconsumed_keys = set(settings.keys()) - set(self.schema.keys())
+        if unconsumed_keys:
+            raise self.ImproperlyConfigured('Unknown setting(s): {}'.format(', '.join(unconsumed_keys)))
+
+        # Ensure that all values in the settings data pass standard Conformity field validation
+        for key, value in settings.items():
+            try:
+                validate(self.schema[key], value, "setting '{}'".format(key))
+            except ValidationError as e:
+                raise self.ImproperlyConfigured(*e.args)
+
+        # Once all checks have passed, atomically set the internal settings data
+        self._data = settings
+
+    @classmethod
+    def _merge_mappings(cls, data, defaults):  # type: (SettingsData, SettingsData) -> SettingsData
+        new_data = {}  # type: Dict[six.text_type, Any]
+
+        for key in set(itertools.chain(data.keys(), defaults.keys())):
+            if key in data and key in defaults:
+                if isinstance(data[key], Mapping) and isinstance(defaults[key], Mapping):
+                    new_data[key] = cls._merge_mappings(data[key], defaults[key])
+                else:
+                    new_data[key] = data[key]
+            elif key in data:
+                new_data[key] = data[key]
+            else:
+                new_data[key] = defaults[key]
+
+        return new_data
+
+    def keys(self):  # type: () -> SettingsKeysView
+        """
+        Returns a `KeysView` of the settings data (even in Python 2).
+
+        :return: A view of the unicode string keys in this settings data.
+        """
+        return cast(SettingsKeysView, self._data.keys())
+
+    def values(self):  # type: () -> SettingsValuesView
+        """
+        Returns a `ValuesView` of the settings data (even in Python 2).
+
+        :return: A view of the values in this settings data.
+        """
+        return self._data.values()
+
+    def items(self):  # type: () -> SettingsItemsView
+        """
+        Returns an `ItemsView` of the settings data (even in Python 2).
+
+        :return: A view of unicode string keys and their values in this settings data.
+        """
+        return cast(SettingsItemsView, self._data.items())
+
+    def get(self, key, default=None):  # type: (six.text_type, Optional[_VT]) -> Optional[_VT]
+        """
+        Returns the value associated with the given key, or the default if specified as an argument, or `None` if no
+        default is specified.
+
+        :param key: The key to look up
+        :param default: The default to return if the key does not exist (which itself defaults to `None`)
+
+        :return: The value associated with the given key, or the appropriate default.
+        """
+        return self._data.get(key, default)
+
+    def __getitem__(self, key):  # type: (six.text_type) -> Any
+        """
+        Returns the value associated with the given key, or raises a `KeyError` if it does not exist.
+
+        :param key: The key to look up
+
+        :return: The value associated with the given key.
+
+        :raises: KeyError
+        """
+        return self._data[key]
+
+    def __len__(self):  # type: () -> int
+        """
+        Returns the number of keys in the root of this settings data.
+
+        :return: The number of keys.
+        """
+        return len(self._data)
+
+    def __iter__(self):  # type: () -> Iterator[six.text_type]
+        """
+        Returns an iterator over the keys of this settings data.
+
+        :return: An iterator of unicode strings.
+        """
+        return iter(self._data)
+
+    def __contains__(self, key):  # type: (Any) -> bool
+        """
+        Indicates whether the specific key exists in this settings data.
+
+        :param key: The key to check
+
+        :return: `True` if the key exists and `False` if it does not.
+        """
+        return key in self._data
+
+    def __eq__(self, other):  # type: (Any) -> bool
+        """
+        Indicates whether the other object provided is an instance of the same Settings subclass as this Settings
+        subclass and its settings data matches this settings data.
+
+        :param other: The other object to check
+
+        :return: `True` if the objects are equal, `False` if they are not.
+        """
+        return isinstance(other, self.__class__) and self._data == other._data
+
+    def __ne__(self, other):  # type: (Any) -> bool
+        """
+        Indicates the reverse of __eq__.
+
+        :param other: The other object to check
+
+        :return: `False` if the objects are equal, `True` if they are not.
+        """
+        return not self.__eq__(other)

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,7 @@ from __future__ import (
     unicode_literals,
 )
 
-from setuptools import (
-    find_packages,
-    setup,
-)
+from setuptools import setup
 
 from conformity import __version__
 
@@ -25,10 +22,11 @@ country_requires = [
 ]
 
 tests_require = [
+    'freezegun',
+    'mypy;python_version>"3.4"',
     'pytest',
     'pytest-cov',
     'pytest-runner',
-    'freezegun',
     'pytz',
 ] + currency_requires + country_requires
 
@@ -40,7 +38,7 @@ setup(
     description='Cacheable schema description and validation',
     long_description=readme(),
     url='http://github.com/eventbrite/conformity',
-    packages=list(map(str, find_packages(exclude=['*.tests', '*.tests.*', 'tests.*', 'tests']))),
+    packages=[str('conformity')],
     package_data={str('conformity'): [str('py.typed')]},  # PEP 561
     zip_safe=False,  # PEP 561
     include_package_data=True,
@@ -67,9 +65,9 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Software Development',
     ],
 )

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -442,7 +442,7 @@ class FieldTests(unittest.TestCase):
 
     def test_anything(self):  # type: () -> None
         with pytest.raises(TypeError):
-            Anything(b'Not unicode')
+            Anything(b'Not unicode')  # type: ignore
 
         assert Anything('Test description 1').introspect() == {
             'type': 'anything',

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,707 @@
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
+
+import decimal
+from typing import (
+    ItemsView,
+    KeysView,
+    ValuesView,
+)
+
+import pytest
+import six
+
+from conformity import fields
+from conformity.settings import (  # noqa: F401 TODO Python 3
+    Settings,
+    SettingsData,
+    SettingsSchema,
+)
+
+
+class NonSettingsMixinHasNoImpact(object):
+    def do_something(self):
+        pass
+
+
+class SettingsOne(Settings):
+    schema = {
+        'foo': fields.UnicodeString(),
+        'bar': fields.Boolean(),
+    }  # type: SettingsSchema
+
+    defaults = {
+        'bar': False,
+    }  # type: SettingsData
+
+
+class SettingsTwo(Settings):
+    schema = {
+        'bar': fields.Integer(),
+        'baz': fields.Dictionary(
+            {
+                'inner_foo': fields.UnicodeString(),
+                'inner_bar': fields.Boolean(),
+                'inner_baz': fields.List(fields.Integer()),
+                'inner_qux': fields.Dictionary(
+                    {
+                        'most_inner_foo': fields.Boolean(),
+                        'most_inner_bar': fields.UnicodeString(),
+                    },
+                ),
+            },
+        ),
+    }  # type: SettingsSchema
+
+    defaults = {
+        'bar': 1,
+        'baz': {
+            'inner_foo': 'Default inner',
+            'inner_qux': {
+                'most_inner_bar': 'Default most inner'
+            }
+        },
+    }  # type: SettingsData
+
+
+class SettingsThree(Settings):
+    schema = {
+        'baz': fields.List(fields.Float()),
+        'qux': fields.Float(),
+    }  # type: SettingsSchema
+
+    defaults = {
+        'qux': 1.234,
+    }  # type: SettingsData
+
+
+class SettingsFour(SettingsThree):
+    schema = {
+        'qux': fields.Decimal(),
+        'new': fields.ByteString(),
+        'old': fields.UnicodeString(),
+    }  # type: SettingsSchema
+
+    defaults = {
+        'qux': decimal.Decimal('1.234'),
+        'old': 'Default old',
+    }  # type: SettingsData
+
+
+class SettingsOneTwo(SettingsOne, SettingsTwo):
+    pass
+
+
+class SettingsTwoOne(SettingsTwo, NonSettingsMixinHasNoImpact, SettingsOne):
+    pass
+
+
+class SettingsTwoOneWithOverrides(SettingsTwo, SettingsOne):
+    schema = {
+        'baz': fields.ByteString(),
+    }  # type: SettingsSchema
+
+    defaults = {
+        'baz': b'This is the default',
+    }  # type: SettingsData
+
+
+class SettingsOneThree(SettingsOne, SettingsThree):
+    pass
+
+
+class SettingsOneFour(SettingsOne, SettingsFour):
+    pass
+
+
+class SettingsTwoFour(SettingsTwo, SettingsFour):
+    pass
+
+
+class SettingsTwoFourWithOverrides(SettingsTwo, SettingsFour):
+    schema = {
+        'baz': fields.ByteString(),
+    }  # type: SettingsSchema
+
+    defaults = {
+        'baz': b'This is the default',
+    }  # type: SettingsData
+
+
+class SettingsOneTwoThree(SettingsOne, SettingsTwo, NonSettingsMixinHasNoImpact, SettingsThree):
+    pass
+
+
+class SettingsThreeTwoOne(SettingsThree, SettingsTwo, NonSettingsMixinHasNoImpact, SettingsOne):
+    pass
+
+
+class SettingsOneTwoThreeWithOverrides(SettingsOne, SettingsTwo, SettingsThree):
+    schema = {
+        'baz': fields.ByteString(),
+    }  # type: SettingsSchema
+
+    defaults = {
+        'baz': b'This is the default',
+    }  # type: SettingsData
+
+
+class SettingsOneTwoThreeWithOverridesExtended(SettingsOneTwoThreeWithOverrides):
+    schema = {
+        'qux': fields.Decimal(),
+        'new': fields.ByteString(),
+        'old': fields.UnicodeString(),
+    }  # type: SettingsSchema
+
+    defaults = {
+        'qux': decimal.Decimal('1.234'),
+        'old': 'Default old',
+    }  # type: SettingsData
+
+
+# noinspection PyUnusedLocal,PyProtectedMember
+def test_meta_prohibits_non_settings_subclass():
+    from conformity.settings import _SettingsMetaclass
+
+    with pytest.raises(TypeError):
+        @six.add_metaclass(_SettingsMetaclass)
+        class NotASettings(object):
+            schema = {
+                'foo': fields.UnicodeString(),
+                'bar': fields.Boolean(),
+            }  # type: SettingsSchema
+
+            defaults = {
+                'bar': False,
+            }  # type: SettingsData
+
+
+class TestSettingsOne(object):
+    def test_schema_correct(self):
+        assert SettingsOne.schema == {
+            'foo': fields.UnicodeString(),
+            'bar': fields.Boolean(),
+        }
+
+    def test_defaults_correct(self):
+        assert SettingsOne.defaults == {
+            'bar': False,
+        }
+
+    def test_validation(self):
+        with pytest.raises(Settings.ImproperlyConfigured):
+            SettingsOne({})
+
+        with pytest.raises(Settings.ImproperlyConfigured):
+            SettingsOne({
+                'foo': b'Not a unicode string',
+                'bar': True,
+            })
+
+        SettingsOne({
+            'foo': 'Cool',
+            'bar': True,
+        })
+
+        settings = SettingsOne({'foo': 'Uncool'})
+        assert settings['foo'] == 'Uncool'
+        assert settings['bar'] is False
+
+        with pytest.raises(Settings.ImproperlyConfigured):
+            SettingsOne({
+                'foo': 'Cool',
+                'bar': True,
+                'unknown': 'Not supported',
+            })
+
+    def test_standard_mapping_methods(self):
+        settings = SettingsOne({
+            'foo': 'Cool',
+            'bar': True,
+        })
+
+        keys = settings.keys()
+        assert isinstance(keys, KeysView if not six.PY2 else list)
+        keys = list(keys)
+        assert 'foo' in keys
+        assert 'bar' in keys
+
+        values = settings.values()
+        assert isinstance(values, ValuesView if not six.PY2 else list)
+        values = list(values)
+        assert 'Cool' in values
+        assert True in values
+
+        items = settings.items()
+        assert isinstance(items, ItemsView if not six.PY2 else list)
+        items = list(items)
+        assert ('foo', 'Cool') in items
+        assert ('bar', True) in items
+
+        assert settings.get('foo') == 'Cool'
+        assert settings.get('bar', False) is True
+        assert settings.get('baz') is None
+        assert settings.get('baz', False) is False
+        assert settings.get('baz', 3) == 3
+
+        assert settings['foo'] == 'Cool'
+        assert settings['bar'] is True
+        with pytest.raises(KeyError):
+            _ = settings['baz']  # noqa: F841
+
+        assert len(settings) == 2
+
+        for key in settings:
+            assert key in ('foo', 'bar')
+
+        assert 'foo' in settings
+        assert 'bar' in settings
+        assert 'baz' not in settings
+
+        assert settings == settings
+        assert settings == SettingsOne({
+            'foo': 'Cool',
+            'bar': True,
+        })
+        assert SettingsOne({
+            'foo': 'Cool',
+            'bar': True,
+        }) == settings
+        assert settings != SettingsOne({
+            'foo': 'Uncool',
+            'bar': True,
+        })
+
+
+class TestSettingsTwo(object):
+    def test_schema_correct(self):
+        assert SettingsTwo.schema == {
+            'bar': fields.Integer(),
+            'baz': fields.Dictionary(
+                {
+                    'inner_foo': fields.UnicodeString(),
+                    'inner_bar': fields.Boolean(),
+                    'inner_baz': fields.List(fields.Integer()),
+                    'inner_qux': fields.Dictionary(
+                        {
+                            'most_inner_foo': fields.Boolean(),
+                            'most_inner_bar': fields.UnicodeString(),
+                        },
+                    ),
+                },
+            ),
+        }
+
+    def test_defaults_correct(self):
+        assert SettingsTwo.defaults == {
+            'bar': 1,
+            'baz': {
+                'inner_foo': 'Default inner',
+                'inner_qux': {
+                    'most_inner_bar': 'Default most inner'
+                }
+            },
+        }
+
+    def test_validation(self):
+        with pytest.raises(Settings.ImproperlyConfigured) as error_context:
+            SettingsTwo({})
+
+        assert '- inner_bar: Missing key: inner_bar' in error_context.value.args[0]
+        assert '- inner_baz: Missing key: inner_baz' in error_context.value.args[0]
+        assert '- inner_qux.most_inner_foo: Missing key: most_inner_foo' in error_context.value.args[0]
+
+        settings = SettingsTwo({
+            'baz': {
+                'inner_bar': True,
+                'inner_baz': [3, 7, 4],
+                'inner_qux': {
+                    'most_inner_foo': False,
+                },
+            },
+        })
+        assert settings['bar'] == 1
+        assert settings['baz']['inner_foo'] == 'Default inner'
+        assert settings['baz']['inner_bar'] is True
+        assert settings['baz']['inner_baz'] == [3, 7, 4]
+        assert settings['baz']['inner_qux']['most_inner_foo'] is False
+        assert settings['baz']['inner_qux']['most_inner_bar'] == 'Default most inner'
+
+        with pytest.raises(Settings.ImproperlyConfigured) as error_context:
+            SettingsTwo({
+                'baz': {
+                    'inner_bar': 'not a bool',
+                    'inner_baz': [3, 7, 4],
+                    'inner_qux': {
+                        'most_inner_foo': False,
+                    },
+                },
+            })
+
+        assert '- inner_bar: Not a boolean' in error_context.value.args[0]
+
+        with pytest.raises(Settings.ImproperlyConfigured) as error_context:
+            SettingsTwo({
+                'baz': {
+                    'inner_bar': True,
+                    'inner_baz': [3, 7, 4],
+                    'inner_qux': {
+                        'most_inner_foo': False,
+                        'most_inner_bar': b'not unicode'
+                    },
+                },
+            })
+
+        assert '- inner_qux.most_inner_bar: Not a unicode string' in error_context.value.args[0]
+
+        with pytest.raises(Settings.ImproperlyConfigured) as error_context:
+            SettingsTwo({
+                'baz': {
+                    'inner_bar': True,
+                    'inner_baz': [3, 7, 4],
+                    'inner_qux': {
+                        'most_inner_foo': False,
+                        'not_defined': 'Neat',
+                    },
+                },
+            })
+
+        assert '- inner_qux: Extra keys present: not_defined' in error_context.value.args[0]
+
+        with pytest.raises(Settings.ImproperlyConfigured) as error_context:
+            SettingsTwo({
+                'baz': {
+                    'inner_bar': True,
+                    'inner_baz': [3, 7, 4],
+                    'inner_qux': {
+                        'most_inner_foo': False,
+                    },
+                },
+                'not_in_schema': 'Nope nope nope',
+                'also_not_part_of_schema': True,
+            })
+
+        assert 'Unknown setting(s): ' in error_context.value.args[0]
+        assert 'not_in_schema' in error_context.value.args[0]
+        assert 'also_not_part_of_schema' in error_context.value.args[0]
+
+
+class TestSettingsThree(object):
+    def test_schema_correct(self):
+        assert SettingsThree.schema == {
+            'baz': fields.List(fields.Float()),
+            'qux': fields.Float(),
+        }
+
+    def test_defaults_correct(self):
+        assert SettingsThree.defaults == {
+            'qux': 1.234,
+        }
+
+    def test_validation(self):
+        with pytest.raises(Settings.ImproperlyConfigured):
+            SettingsThree({})
+
+        settings = SettingsThree({
+            'baz': [8, 3, 56],
+        })
+        assert settings['baz'] == [8, 3, 56]
+        assert settings['qux'] == 1.234
+
+        settings = SettingsThree({
+            'baz': [21, 42],
+            'qux': 5.678
+        })
+        assert settings['baz'] == [21, 42]
+        assert settings['qux'] == 5.678
+
+        with pytest.raises(Settings.ImproperlyConfigured):
+            SettingsThree({
+                'baz': ['hello', 3, 56],
+            })
+
+        with pytest.raises(Settings.ImproperlyConfigured):
+            SettingsThree({
+                'baz': [8, 3, 56],
+                'not_in_schema': True,
+            })
+
+
+class TestSettingsFour(object):
+    def test_schema_correct(self):
+        assert SettingsFour.schema == {
+            'baz': fields.List(fields.Float()),
+            'qux': fields.Decimal(),
+            'new': fields.ByteString(),
+            'old': fields.UnicodeString(),
+        }
+
+    def test_defaults_correct(self):
+        assert SettingsFour.defaults == {
+            'qux': decimal.Decimal('1.234'),
+            'old': 'Default old',
+        }
+
+
+class TestSettingsOneTwo(object):
+    def test_schema_correct(self):
+        assert SettingsOneTwo.schema == {
+            'foo': fields.UnicodeString(),
+            'bar': fields.Boolean(),
+            'baz': fields.Dictionary(
+                {
+                    'inner_foo': fields.UnicodeString(),
+                    'inner_bar': fields.Boolean(),
+                    'inner_baz': fields.List(fields.Integer()),
+                    'inner_qux': fields.Dictionary(
+                        {
+                            'most_inner_foo': fields.Boolean(),
+                            'most_inner_bar': fields.UnicodeString(),
+                        },
+                    ),
+                },
+            ),
+        }
+
+    def test_defaults_correct(self):
+        assert SettingsOneTwo.defaults == {
+            'bar': False,
+            'baz': {
+                'inner_foo': 'Default inner',
+                'inner_qux': {
+                    'most_inner_bar': 'Default most inner'
+                }
+            },
+        }
+
+
+class TestSettingsTwoOne(object):
+    def test_schema_correct(self):
+        assert SettingsTwoOne.schema == {
+            'foo': fields.UnicodeString(),
+            'bar': fields.Integer(),
+            'baz': fields.Dictionary(
+                {
+                    'inner_foo': fields.UnicodeString(),
+                    'inner_bar': fields.Boolean(),
+                    'inner_baz': fields.List(fields.Integer()),
+                    'inner_qux': fields.Dictionary(
+                        {
+                            'most_inner_foo': fields.Boolean(),
+                            'most_inner_bar': fields.UnicodeString(),
+                        },
+                    ),
+                },
+            ),
+        }
+
+    def test_defaults_correct(self):
+        assert SettingsTwoOne.defaults == {
+            'bar': 1,
+            'baz': {
+                'inner_foo': 'Default inner',
+                'inner_qux': {
+                    'most_inner_bar': 'Default most inner'
+                }
+            },
+        }
+
+
+class TestSettingsTwoOneWithOverrides(object):
+    def test_schema_correct(self):
+        assert SettingsTwoOneWithOverrides.schema == {
+            'foo': fields.UnicodeString(),
+            'bar': fields.Integer(),
+            'baz': fields.ByteString(),
+        }
+
+    def test_defaults_correct(self):
+        assert SettingsTwoOneWithOverrides.defaults == {
+            'bar': 1,
+            'baz': b'This is the default',
+        }
+
+
+class TestSettingsOneThree(object):
+    def test_schema_correct(self):
+        assert SettingsOneThree.schema == {
+            'foo': fields.UnicodeString(),
+            'bar': fields.Boolean(),
+            'baz': fields.List(fields.Float()),
+            'qux': fields.Float(),
+        }
+
+    def test_defaults_correct(self):
+        assert SettingsOneThree.defaults == {
+            'bar': False,
+            'qux': 1.234,
+        }
+
+
+class TestSettingsOneFour(object):
+    def test_schema_correct(self):
+        assert SettingsOneFour.schema == {
+            'foo': fields.UnicodeString(),
+            'bar': fields.Boolean(),
+            'baz': fields.List(fields.Float()),
+            'qux': fields.Decimal(),
+            'new': fields.ByteString(),
+            'old': fields.UnicodeString(),
+        }
+
+    def test_defaults_correct(self):
+        assert SettingsOneFour.defaults == {
+            'bar': False,
+            'qux': decimal.Decimal('1.234'),
+            'old': 'Default old',
+        }
+
+
+class TestSettingsTwoFour(object):
+    def test_schema_correct(self):
+        assert SettingsTwoFour.schema == {
+            'bar': fields.Integer(),
+            'baz': fields.Dictionary(
+                {
+                    'inner_foo': fields.UnicodeString(),
+                    'inner_bar': fields.Boolean(),
+                    'inner_baz': fields.List(fields.Integer()),
+                    'inner_qux': fields.Dictionary(
+                        {
+                            'most_inner_foo': fields.Boolean(),
+                            'most_inner_bar': fields.UnicodeString(),
+                        },
+                    ),
+                },
+            ),
+            'qux': fields.Decimal(),
+            'new': fields.ByteString(),
+            'old': fields.UnicodeString(),
+        }
+
+    def test_defaults_correct(self):
+        assert SettingsTwoFour.defaults == {
+            'bar': 1,
+            'baz': {
+                'inner_foo': 'Default inner',
+                'inner_qux': {
+                    'most_inner_bar': 'Default most inner'
+                }
+            },
+            'qux': decimal.Decimal('1.234'),
+            'old': 'Default old',
+        }
+
+
+class TestSettingsTwoFourWithOverrides(object):
+    def test_schema_correct(self):
+        assert SettingsTwoFourWithOverrides.schema == {
+            'bar': fields.Integer(),
+            'baz': fields.ByteString(),
+            'qux': fields.Decimal(),
+            'new': fields.ByteString(),
+            'old': fields.UnicodeString(),
+        }
+
+    def test_defaults_correct(self):
+        assert SettingsTwoFourWithOverrides.defaults == {
+            'bar': 1,
+            'baz': b'This is the default',
+            'qux': decimal.Decimal('1.234'),
+            'old': 'Default old',
+        }
+
+
+class TestSettingsOneTwoThree(object):
+    def test_schema_correct(self):
+        assert SettingsOneTwoThree.schema == {
+            'foo': fields.UnicodeString(),
+            'bar': fields.Boolean(),
+            'baz': fields.Dictionary(
+                {
+                    'inner_foo': fields.UnicodeString(),
+                    'inner_bar': fields.Boolean(),
+                    'inner_baz': fields.List(fields.Integer()),
+                    'inner_qux': fields.Dictionary(
+                        {
+                            'most_inner_foo': fields.Boolean(),
+                            'most_inner_bar': fields.UnicodeString(),
+                        },
+                    ),
+                },
+            ),
+            'qux': fields.Float(),
+        }
+
+    def test_defaults_correct(self):
+        assert SettingsOneTwoThree.defaults == {
+            'bar': False,
+            'baz': {
+                'inner_foo': 'Default inner',
+                'inner_qux': {
+                    'most_inner_bar': 'Default most inner'
+                }
+            },
+            'qux': 1.234,
+        }
+
+
+class TestSettingsThreeTwoOne(object):
+    def test_schema_correct(self):
+        assert SettingsThreeTwoOne.schema == {
+            'foo': fields.UnicodeString(),
+            'bar': fields.Integer(),
+            'baz': fields.List(fields.Float()),
+            'qux': fields.Float(),
+        }
+
+    def test_defaults_correct(self):
+        assert SettingsThreeTwoOne.defaults == {
+            'bar': 1,
+            'baz': {
+                'inner_foo': 'Default inner',
+                'inner_qux': {
+                    'most_inner_bar': 'Default most inner'
+                }
+            },
+            'qux': 1.234,
+        }
+
+
+class TestSettingsOneTwoThreeWithOverrides(object):
+    def test_schema_correct(self):
+        assert SettingsOneTwoThreeWithOverrides.schema == {
+            'foo': fields.UnicodeString(),
+            'bar': fields.Boolean(),
+            'baz': fields.ByteString(),
+            'qux': fields.Float(),
+        }
+
+    def test_defaults_correct(self):
+        assert SettingsOneTwoThreeWithOverrides.defaults == {
+            'bar': False,
+            'baz': b'This is the default',
+            'qux': 1.234,
+        }
+
+
+class TestSettingsOneTwoThreeWithOverridesExtended(object):
+    def test_schema_correct(self):
+        assert SettingsOneTwoThreeWithOverridesExtended.schema == {
+            'foo': fields.UnicodeString(),
+            'bar': fields.Boolean(),
+            'baz': fields.ByteString(),
+            'qux': fields.Decimal(),
+            'new': fields.ByteString(),
+            'old': fields.UnicodeString(),
+        }
+
+    def test_defaults_correct(self):
+        assert SettingsOneTwoThreeWithOverridesExtended.defaults == {
+            'bar': False,
+            'baz': b'This is the default',
+            'qux': decimal.Decimal('1.234'),
+            'old': 'Default old',
+        }


### PR DESCRIPTION
This commit implements #65. PySOA's `Settings` are being used for many things beyond just PySOA - several other projects not otherwise using PySOA are importing PySOA just to use its `Settings` feature. Based on this use case, `Settings` is an appropriate member of the Conformity domain, so this is the Conformity commit to migrate `Settings` from PySOA to Conformity. There will be a corresponding PySOA commit to adopt this new Conformity feature.