### PR TITLE
[MINOR] Add Python logging configuration validation schema

### DIFF
--- a/conformity/fields/__init__.py
+++ b/conformity/fields/__init__.py
@@ -40,9 +40,11 @@ from conformity.fields.net import (
     IPv6Address,
 )
 from conformity.fields.structures import (
+    AdditionalCollectionValidator,
     Dictionary,
     List,
     SchemalessDictionary,
+    Sequence,
     Set,
     Tuple,
 )
@@ -56,6 +58,7 @@ from conformity.fields.temporal import (
 
 
 __all__ = (
+    'AdditionalCollectionValidator',
     'All',
     'Any',
     'Anything',
@@ -85,6 +88,7 @@ __all__ = (
     'Polymorph',
     'PythonPath',
     'SchemalessDictionary',
+    'Sequence',
     'Set',
     'Time',
     'TimeDelta',

--- a/conformity/fields/logging.py
+++ b/conformity/fields/logging.py
@@ -1,0 +1,294 @@
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
+
+import collections
+import logging
+from typing import (  # noqa: F401 TODO Python 3
+    Any as AnyType,
+    Hashable as HashableType,
+    List as ListType,
+    Mapping,
+    Tuple as TupleType,
+)
+
+from conformity import fields
+from conformity.error import (
+    ERROR_CODE_UNKNOWN,
+    Error,
+)
+
+
+__all__ = (
+    'PythonLogLevel',
+    'PYTHON_LOGGER_SCHEMA',
+    'PYTHON_LOGGING_CONFIG_SCHEMA',
+    'PYTHON_ROOT_LOGGER_SCHEMA',
+)
+
+
+class PythonLogLevel(fields.Constant):
+    """
+    A pre-defined `Constant` field with all the possible Python log levels populated. All you need is a description for
+    documentation.
+    """
+
+    def __init__(self, description=None):
+        """
+        Constructs a `PythonLogLevel` field.
+
+        :param description: The description for documentation
+        """
+        super(PythonLogLevel, self).__init__(
+            logging.getLevelName(logging.DEBUG),
+            logging.getLevelName(logging.INFO),
+            logging.getLevelName(logging.WARNING),
+            logging.getLevelName(logging.ERROR),
+            logging.getLevelName(logging.CRITICAL),
+            description=description,
+        )
+
+
+class _LoggingValidator(fields.AdditionalCollectionValidator[Mapping[HashableType, AnyType]]):
+    @staticmethod
+    def _ensure_configured(
+        source,  # type: Mapping[str, AnyType]
+        name,  # type: str
+        errors,  # type: ListType[Error]
+        referencer_noun,  # type: str
+        referencer,  # type: str
+        referenced_noun,  # type: str
+        pointer,  # type: str
+        pointer_args,  # type: TupleType[AnyType, ...]
+    ):
+        if name not in source:
+            errors.append(Error(
+                code=ERROR_CODE_UNKNOWN,
+                message=(
+                    '{referencer_noun} "{referencer}" references {referenced_noun} "{name}", which is not configured.'
+                ).format(
+                    referencer_noun=referencer_noun,
+                    referencer=referencer,
+                    referenced_noun=referenced_noun,
+                    name=name,
+                ),
+                pointer=pointer.format(*pointer_args),
+            ))
+
+    def errors(self, value):  # type: (Mapping[HashableType, AnyType]) -> ListType[Error]
+        errors = []  # type: ListType[Error]
+
+        formatters = value.get('formatters', {})  # type: Mapping[str, Mapping[str, str]]
+        filters = value.get('filters', {})  # type: Mapping[str, Mapping[str, AnyType]]
+        handlers = value.get('handlers', {})  # type: Mapping[str, Mapping[str, AnyType]]
+        loggers = value.get('loggers', {})  # type: Mapping[str, Mapping[str, AnyType]]
+        root = value.get('root', {})  # type: Mapping[str, AnyType]
+
+        if filters:
+            for filter_name, filter_config in filters.items():
+                standard_keys = 0
+                if '()' in filter_config:
+                    standard_keys = 1
+                    is_standard = filter_config['()'] == 'logging.Filter'
+                else:
+                    is_standard = True
+                if 'name' in filter_config:
+                    standard_keys += 1
+
+                if is_standard and len(filter_config) > standard_keys:
+                    errors.append(Error(
+                        code=ERROR_CODE_UNKNOWN,
+                        message='Not all keys supported for filter named "{}"'.format(filter_name),
+                        pointer='filters.{}'.format(filter_name),
+                    ))
+
+        if value.get('incremental', False) is not True:
+            if handlers:
+                for handler_name, handler_config in handlers.items():
+                    if 'formatter' in handler_config:
+                        self._ensure_configured(
+                            formatters, handler_config['formatter'], errors,
+                            'Handler', handler_name, 'formatter', 'handlers.{}.formatter', (handler_name, ),
+                        )
+
+                    handler_filters = handler_config.get('filters', [])  # type: ListType[str]
+                    for i, filter in enumerate(handler_filters):
+                        self._ensure_configured(
+                            filters, filter, errors,
+                            'Handler', handler_name, 'filter', 'handlers.{}.filters.{}', (handler_name, i),
+                        )
+
+            if loggers:
+                for logger_name, logger_config in loggers.items():
+                    logger_filters = logger_config.get('filters', [])  # type: ListType[str]
+                    for i, filter in enumerate(logger_filters):
+                        self._ensure_configured(
+                            filters, filter, errors,
+                            'Logger', logger_name, 'filter', 'loggers.{}.filters.{}', (logger_name, i),
+                        )
+
+                    logger_handlers = logger_config.get('handlers', [])  # type: ListType[str]
+                    for i, handler in enumerate(logger_handlers):
+                        self._ensure_configured(
+                            handlers, handler, errors,
+                            'Logger', logger_name, 'handler', 'loggers.{}.handlers.{}', (logger_name, i),
+                        )
+
+            if root:
+                root_filters = root.get('filters', [])  # type: ListType[str]
+                for i, filter in enumerate(root_filters):
+                    self._ensure_configured(
+                        filters, filter, errors,
+                        'Logger', 'root', 'filter', 'root.filters.{}', (i, ),
+                    )
+
+                root_handlers = root.get('handlers', [])  # type: ListType[str]
+                for i, handler in enumerate(root_handlers):
+                    self._ensure_configured(
+                        handlers, handler, errors,
+                        'Logger', 'root', 'handler', 'root.handlers.{}', (i, ),
+                    )
+
+        return errors
+
+
+PYTHON_ROOT_LOGGER_SCHEMA = fields.Dictionary(
+    {
+        'level': PythonLogLevel(
+            description='The logging level at or above which this logger will handle logging events and send them to '
+                        'its configured handlers.',
+        ),
+        'filters': fields.List(
+            fields.UnicodeString(),
+            description='A list of references to keys from `filters` for assigning those filters to this logger.',
+        ),
+        'handlers': fields.List(
+            fields.UnicodeString(),
+            description='A list of references to keys from `handlers` for assigning those handlers to this logger.',
+        ),
+    },
+    optional_keys=('level', 'filters', 'handlers'),
+)
+
+PYTHON_LOGGER_SCHEMA = PYTHON_ROOT_LOGGER_SCHEMA.extend(
+    contents={
+        'propagate': fields.Boolean(
+            description='Whether logging events handled by this logger should propagate to other loggers and/or the '
+                        'root logger. Defaults to `True`.'
+        ),
+    },
+    optional_keys=('propagate', ),
+)
+
+
+PYTHON_LOGGING_CONFIG_SCHEMA = fields.Dictionary(
+    collections.OrderedDict((
+        ('version', fields.Integer(gte=1, lte=1)),
+        ('formatters', fields.SchemalessDictionary(
+            key_type=fields.UnicodeString(),
+            value_type=fields.Dictionary(
+                {
+                    'format': fields.UnicodeString(
+                        description='The format string for this formatter (see '
+                                    'https://docs.python.org/3/library/logging.html#logrecord-attributes).',
+                    ),
+                    'datefmt': fields.UnicodeString(
+                        description='The optional date format used when formatting dates in the log output (see '
+                                    'https://docs.python.org/3/library/datetime.html#strftime-strptime-behavior).',
+                    ),
+                },
+                optional_keys=('datefmt', ),
+            ),
+            description='This defines a mapping of logging formatter names to formatter configurations. The `format` '
+                        'key specifies the log format and the `datefmt` key specifies the date format.',
+        )),
+        ('filters', fields.SchemalessDictionary(
+            key_type=fields.UnicodeString(),
+            value_type=fields.Dictionary(
+                {
+                    '()': fields.TypePath(
+                        base_classes=logging.Filter,
+                        description='The optional, fully-qualified name of the class extending `logging.Filter`, used '
+                                    'to override the default class `logging.Filter`.',
+                    ),
+                    'name': fields.UnicodeString(
+                        description='The optional filter name which will be passed to the `name` argument of the '
+                                    '`logging.Filter` class.',
+                    ),
+                },
+                optional_keys=('()', 'name'),
+                allow_extra_keys=True,
+            ),
+            description='This defines a mapping of logging filter names to filter configurations. If a config has '
+                        'only the `name` key, then `logging.Filter` will be instantiated with that argument. You can '
+                        'specify a `()` key (yes, really) to override the default `logging.Filter` class with a '
+                        'custom filter implementation (which should extend `logging.Filter`). Extra keys are allowed '
+                        'only for custom implementations having extra constructor arguments matching those key names.',
+        )),
+        ('handlers', fields.SchemalessDictionary(
+            key_type=fields.UnicodeString(),
+            value_type=fields.Dictionary(
+                {
+                    'class': fields.TypePath(
+                        base_classes=logging.Handler,
+                        description='The fully-qualified name of the class extending `logging.Handler`.',
+                    ),
+                    'level': PythonLogLevel(
+                        description='The logging level at or above which this handler will emit logging events.',
+                    ),
+                    'formatter': fields.UnicodeString(
+                        description='A reference to a key from `formatters` for assigning that formatter to this '
+                                    'handler.',
+                    ),
+                    'filters': fields.List(
+                        fields.UnicodeString(),
+                        description='A list of references to keys from `filters` for assigning those filters to this '
+                                    'handler.',
+                    ),
+                },
+                optional_keys=('level', 'formatter', 'filters'),
+                allow_extra_keys=True,
+            ),
+            description='This defines a mapping of logging handler names to handler configurations. The `class` key '
+                        'is the importable Python path to the class extending `logging.Handler`. The `level` and '
+                        '`filters` keys apply to all handlers. The `formatter` key is valid for all handlers, but not '
+                        'all handlers will use it. Extra keys are allowed only for handlers having extra constructor '
+                        'arguments matching those key names.',
+        )),
+        ('loggers', fields.SchemalessDictionary(
+            key_type=fields.UnicodeString(),
+            value_type=PYTHON_LOGGER_SCHEMA,
+            description='This defines a mapping of logger names to logger configurations. A log event not handled by '
+                        'one of these configured loggers (if any) will instead be handled by the root logger. A log '
+                        'event handled by one of these configured loggers may still be handled by another logger or '
+                        'the root logger unless its `propagate` key is set to `False`.',
+        )),
+        ('root', PYTHON_ROOT_LOGGER_SCHEMA),
+        ('incremental', fields.Boolean(
+            description='Whether this configuration should be considered incremental to any existing configuration. '
+                        'It defaults to `False` and it is rare that you should ever need to change that.',
+        )),
+        ('disable_existing_loggers', fields.Boolean(
+            description='Whether all existing loggers (objects obtained from `logging.getLogger()`) should be '
+                        'disabled when this logging config is loaded. Take our advice and *always* set this to '
+                        '`False`. It defaults to `True` and you almost never want that, because loggers in '
+                        'already-loaded modules will stop working.',
+        )),
+    )),
+    optional_keys=(
+        'version',
+        'formatters',
+        'filters',
+        'handlers',
+        'root',
+        'loggers',
+        'incremental',
+        'disable_existing_loggers',
+    ),
+    description='Settings to enforce the standard Python logging dictionary-based configuration, as you would load '
+                'with `logging.config.dictConfig()`. For more information than the documentation here, see '
+                'https://docs.python.org/3/library/logging.config.html#configuration-dictionary-schema.',
+    additional_validator=_LoggingValidator(),
+)
+""""""  # Empty docstring to make autodoc document this data

--- a/conformity/sphinx_ext/linkcode.py
+++ b/conformity/sphinx_ext/linkcode.py
@@ -95,7 +95,10 @@ def create_linkcode_resolve(
             if not (source and start_line) or start_line == 1:
                 source, start_line = inspect.getsourcelines(obj)
         except (TypeError, OSError):
-            source, start_line = inspect.getsourcelines(obj)
+            try:
+                source, start_line = inspect.getsourcelines(obj)
+            except TypeError:
+                source, start_line = [], 0
         if source and start_line:
             suffix = f'#L{start_line}-L{start_line + len(source) - 1}'
 

--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -3,7 +3,8 @@ Using Conformity Fields
 
 The core of Conformity's schema validation lies within its extensive set of fields, detailed here. Most fields can
 be imported either from their specific package (detailed below) or from ``conformity.fields``, but fields that require
-extra dependencies (such as `PyCountry`_ or `Currint`_) must be imported directly from their specific package.
+extra dependencies (such as `PyCountry`_ or `Currint`_) and fields and constants from ``conformity.fields.logging``
+must be imported directly from their specific package.
 
 .. contents:: Contents
    :depth: 3
@@ -594,6 +595,24 @@ The final argument of note is ``eager_default_validation``. It is ignored unless
 ``default_path`` is specified and ``eager_default_validation`` is ``True`` (the default), the class at ``default_path``
 will be eagerly imported and resolved and checked to make sure it has a valid ``@ClassConfigurationSchema.provider``
 decorator.
+
+
+Logging Helpers
+---------------
+
+The `Python Logging dictionary configuration <https://docs.python.org/3/library/logging.config.html#configuration-dictionary-schema>`_
+is a common dictionary-based settings/configuration object in need of validation. Python does some level of validation
+on values passed to ``logging.config.dictConfig``, but that validation is not necessarily thorough, and the errors
+arising from an invalid configuration are often cryptic and hard to track down.
+
+The `conformity.fields.logging <reference.html#conformity.fields.logging.PythonLogLevel>`_ module contains one helper
+field ``PythonLogLevel``, which is a simple ``Constant`` with log level names as the pre-defined values, and some
+helper schemas to make it easier for you to accurately validate logging settings:
+
+- ``PYTHON_ROOT_LOGGER_SCHEMA``: The schema (``Dictionary`` instance) for the root logger
+- ``PYTHON_LOGGER_SCHEMA``: The schema (``Dictionary`` instance) for all other loggers
+- ``PYTHON_LOGGING_CONFIG_SCHEMA``: The schema (``Dictionary`` instance) for the entire Python logging config
+  dictionary format.
 
 
 .. _create your own:

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -26,6 +26,8 @@ API Reference Documentation
 
 .. automodule:: conformity.fields.meta
 
+.. automodule:: conformity.fields.logging
+
 .. automodule:: conformity.error
 
 .. automodule:: conformity.settings

--- a/docs/sphinx.rst
+++ b/docs/sphinx.rst
@@ -62,6 +62,9 @@ modify it before it gets rendered. It looks for and does the following things:
 - If a class being documented is decorated with ``@fields.ClassConfigurationSchema`` (see
   `Class Configuration Schemas <fields.html#class-configuration-schemas>`_), the extension parses the schema and
   appends documentation to the class docstring detailing the schema requirements for the constructor arguments.
+- If your module has an attribute that is an instance of any Conformity field and that attribute has a docstring
+  directly below it (even an empty one), the extension parses the schema of that field and appends its documentation
+  to the docstring for that attribute.
 
 The Linkcode extension does not have an events to hook in to like the Autodoc extension. Instead, it just provides a
 helper method that you can use to fulfill Linkcode's ``linkcode_resolve`` attribute in ``conf.py``. Writing a

--- a/tests/sphinx_ext/test_autodoc.py
+++ b/tests/sphinx_ext/test_autodoc.py
@@ -27,6 +27,7 @@ from conformity import (
     settings,
     __version__,
 )
+from conformity.fields.logging import PYTHON_LOGGING_CONFIG_SCHEMA
 from conformity.sphinx_ext.autodoc import (
     autodoc_process_docstring,
     autodoc_process_signature,
@@ -301,6 +302,15 @@ def test_autodoc_process_signature(obj, signature, return_annotation, new_signat
     ) == (new_signature, new_return_annotation)
 
 
+def test_autodoc_process_signature_conformity_schema_data():
+    sphinx = cast(Sphinx, mock.MagicMock())
+    options = mock.MagicMock()
+
+    assert autodoc_process_signature(
+        sphinx, 'data', 'path.to.module.DATA_ATTRIBUTE', PYTHON_LOGGING_CONFIG_SCHEMA, options, None, None,
+    ) == (' = pre-defined Conformity schema path.to.module.DATA_ATTRIBUTE', None)
+
+
 def test_autodoc_process_docstring_backticks():
     sphinx = cast(Sphinx, mock.MagicMock())
     options = mock.MagicMock()
@@ -326,6 +336,22 @@ def test_autodoc_process_docstring_backticks():
         "and optionally fields ``'major_value'`` and ``'display'``. This field requires that Currint be installed.",
         '',
     ]
+
+
+def test_autodoc_process_dostring_conformity_schema_data():
+    sphinx = cast(Sphinx, mock.MagicMock())
+    options = mock.MagicMock()
+
+    lines = ['']
+
+    autodoc_process_docstring(sphinx, 'data', 'does not matter', PYTHON_LOGGING_CONFIG_SCHEMA, options, lines)
+
+    assert lines[0] == ''
+    assert lines[1] == ''
+    assert lines[2] == ''
+    assert lines[3].startswith(
+        'strict ``dict``: Settings to enforce the standard Python logging dictionary-based configuration',
+    )
 
 
 def test_autodoc_process_docstring_settings_class():

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,256 @@
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
+
+import copy
+from logging import Filter
+from typing import (  # noqa: F401 TODO Python 3
+    Any as AnyType,
+    Dict,
+)
+
+from conformity.fields.logging import PYTHON_LOGGING_CONFIG_SCHEMA
+
+
+class CustomFilter(Filter):
+    pass
+
+
+base_test_config = {
+    'version': 1,
+    'formatters': {
+        'console': {
+            'format': '%(asctime)s %(levelname)7s %(correlation_id)s %(request_id)s: %(message)s'
+        },
+        'syslog': {
+            'format': (
+                '%(service_name)s_service: %(name)s %(levelname)s %(module)s %(process)d '
+                'correlation_id %(correlation_id)s request_id %(request_id)s %(message)s'
+            ),
+        },
+    },
+    'filters': {
+        'conformity_custom_filter': {
+            '()': 'tests.test_logging.CustomFilter',
+            'custom_argument': 'allowed',
+        },
+    },
+    'handlers': {
+        'file': {
+            'level': 'WARNING',
+            'class': 'logging.FileHandler',
+            'filename': '/does/not/matter.log',
+        },
+        'console': {
+            'level': 'INFO',
+            'class': 'logging.StreamHandler',
+            'formatter': 'console',
+            'filters': ['conformity_custom_filter'],
+        },
+        'syslog': {
+            'level': 'INFO',
+            'class': 'logging.handlers.SysLogHandler',
+            'formatter': 'syslog',
+            'filters': ['conformity_custom_filter'],
+        },
+    },
+    'loggers': {
+        'django.security': {
+            'handlers': ['file'],
+            'level': 'WARNING',
+            'propagate': False,
+        }
+    },
+    'root': {
+        'handlers': ['console'],
+        'level': 'INFO',
+    },
+    'disable_existing_loggers': False,
+}  # type: Dict[str, AnyType]
+
+
+def test_base_test_schema_passes_validation():  # type: () -> None
+    assert PYTHON_LOGGING_CONFIG_SCHEMA.errors(base_test_config) == []
+
+
+def test_invalid_log_level():  # type: () -> None
+    config = copy.deepcopy(base_test_config)
+    config['handlers']['file']['level'] = 'NOT_A_LEVEL'
+
+    errors = PYTHON_LOGGING_CONFIG_SCHEMA.errors(config)
+    assert len(errors) == 1
+    assert errors[0].code == 'UNKNOWN'
+    assert errors[0].pointer == 'handlers.file.level'
+
+    config = copy.deepcopy(base_test_config)
+    config['root']['level'] = 'NOT_A_LEVEL'
+
+    errors = PYTHON_LOGGING_CONFIG_SCHEMA.errors(config)
+    assert len(errors) == 1
+    assert errors[0].code == 'UNKNOWN'
+    assert errors[0].pointer == 'root.level'
+
+
+def test_invalid_filters():  # type: () -> None
+    config = copy.deepcopy(base_test_config)
+    config['filters']['test_bad_1'] = {
+        'not_supported': 3,
+    }
+
+    errors = PYTHON_LOGGING_CONFIG_SCHEMA.errors(config)
+    assert len(errors) == 1
+    assert errors[0].code == 'UNKNOWN'
+    assert errors[0].pointer == 'filters.test_bad_1'
+
+    config = copy.deepcopy(base_test_config)
+    config['filters']['test_bad_2'] = {
+        '()': 'logging.Filter',
+        'name': 'hello',
+        'not_supported': 3,
+    }
+
+    errors = PYTHON_LOGGING_CONFIG_SCHEMA.errors(config)
+    assert len(errors) == 1
+    assert errors[0].code == 'UNKNOWN'
+    assert errors[0].pointer == 'filters.test_bad_2'
+
+
+def test_non_configured_formatters():  # type: () -> None
+    config = copy.deepcopy(base_test_config)
+    config['handlers']['file']['formatter'] = 'non_configured_formatter_1'
+
+    errors = PYTHON_LOGGING_CONFIG_SCHEMA.errors(config)
+    assert len(errors) == 1
+    assert errors[0].code == 'UNKNOWN'
+    assert errors[0].message == 'Handler "file" references formatter "non_configured_formatter_1", ' \
+                                'which is not configured.'
+    assert errors[0].pointer == 'handlers.file.formatter'
+
+    config = copy.deepcopy(base_test_config)
+    del config['formatters']
+    del config['handlers']['syslog']['formatter']
+
+    errors = PYTHON_LOGGING_CONFIG_SCHEMA.errors(config)
+    assert len(errors) == 1
+    assert errors[0].code == 'UNKNOWN'
+    assert errors[0].message == 'Handler "console" references formatter "console", which is not configured.'
+    assert errors[0].pointer == 'handlers.console.formatter'
+
+    config = copy.deepcopy(base_test_config)
+    config['incremental'] = True
+    del config['formatters']
+
+    assert PYTHON_LOGGING_CONFIG_SCHEMA.errors(config) == []
+
+
+def test_non_configured_filters():  # type: () -> None
+    config = copy.deepcopy(base_test_config)
+    config['handlers']['file']['filters'] = ['non_configured_filter_1']
+
+    errors = PYTHON_LOGGING_CONFIG_SCHEMA.errors(config)
+    assert len(errors) == 1
+    assert errors[0].code == 'UNKNOWN'
+    assert errors[0].message == 'Handler "file" references filter "non_configured_filter_1", which is not configured.'
+    assert errors[0].pointer == 'handlers.file.filters.0'
+
+    config = copy.deepcopy(base_test_config)
+    config['loggers']['django.security']['filters'] = ['non_configured_filter_2', 'conformity_custom_filter']
+
+    errors = PYTHON_LOGGING_CONFIG_SCHEMA.errors(config)
+    assert len(errors) == 1
+    assert errors[0].code == 'UNKNOWN'
+    assert errors[0].message == 'Logger "django.security" references filter "non_configured_filter_2", ' \
+                                'which is not configured.'
+    assert errors[0].pointer == 'loggers.django.security.filters.0'
+
+    config = copy.deepcopy(base_test_config)
+    config['root']['filters'] = ['conformity_custom_filter', 'non_configured_filter_3']
+
+    errors = PYTHON_LOGGING_CONFIG_SCHEMA.errors(config)
+    assert len(errors) == 1
+    assert errors[0].code == 'UNKNOWN'
+    assert errors[0].message == 'Logger "root" references filter "non_configured_filter_3", which is not configured.'
+    assert errors[0].pointer == 'root.filters.1'
+
+    config = copy.deepcopy(base_test_config)
+    config['filters'] = {}
+    config['handlers']['console']['filters'] = []
+    config['handlers']['syslog']['filters'] = []
+    config['loggers']['django.security']['filters'] = []
+    config['root']['filters'] = ['conformity_custom_filter', 'non_configured_filter_3']
+
+    errors = PYTHON_LOGGING_CONFIG_SCHEMA.errors(config)
+    assert len(errors) == 2
+    assert errors[0].code == 'UNKNOWN'
+    assert errors[0].message == 'Logger "root" references filter "conformity_custom_filter", which is not configured.'
+    assert errors[0].pointer == 'root.filters.0'
+    assert errors[1].code == 'UNKNOWN'
+    assert errors[1].message == 'Logger "root" references filter "non_configured_filter_3", which is not configured.'
+    assert errors[1].pointer == 'root.filters.1'
+
+    config = copy.deepcopy(base_test_config)
+    config['incremental'] = True
+    config['root']['filters'] = ['conformity_custom_filter', 'non_configured_filter_3']
+
+    assert PYTHON_LOGGING_CONFIG_SCHEMA.errors(config) == []
+
+
+def test_non_configured_handlers():  # type: () -> None
+    config = copy.deepcopy(base_test_config)
+    config['loggers']['django.security']['handlers'] = ['non_configured_handler_1']
+
+    errors = PYTHON_LOGGING_CONFIG_SCHEMA.errors(config)
+    assert len(errors) == 1
+    assert errors[0].code == 'UNKNOWN'
+    assert errors[0].message == 'Logger "django.security" references handler "non_configured_handler_1", ' \
+                                'which is not configured.'
+    assert errors[0].pointer == 'loggers.django.security.handlers.0'
+
+    config = copy.deepcopy(base_test_config)
+    config['root']['handlers'].append('non_configured_handler_2')
+
+    errors = PYTHON_LOGGING_CONFIG_SCHEMA.errors(config)
+    assert len(errors) == 1
+    assert errors[0].code == 'UNKNOWN'
+    assert errors[0].message == 'Logger "root" references handler "non_configured_handler_2", ' \
+                                'which is not configured.'
+    assert errors[0].pointer == 'root.handlers.1'
+
+    config = copy.deepcopy(base_test_config)
+    del config['handlers']
+
+    errors = PYTHON_LOGGING_CONFIG_SCHEMA.errors(config)
+    assert len(errors) == 2
+    assert errors[0].code == 'UNKNOWN'
+    assert errors[0].message == 'Logger "django.security" references handler "file", which is not configured.'
+    assert errors[0].pointer == 'loggers.django.security.handlers.0'
+    assert errors[1].code == 'UNKNOWN'
+    assert errors[1].message == 'Logger "root" references handler "console", which is not configured.'
+    assert errors[1].pointer == 'root.handlers.0'
+
+    config = copy.deepcopy(base_test_config)
+    del config['handlers']
+    del config['root']
+
+    errors = PYTHON_LOGGING_CONFIG_SCHEMA.errors(config)
+    assert len(errors) == 1
+    assert errors[0].code == 'UNKNOWN'
+    assert errors[0].message == 'Logger "django.security" references handler "file", which is not configured.'
+    assert errors[0].pointer == 'loggers.django.security.handlers.0'
+
+    config = copy.deepcopy(base_test_config)
+    del config['handlers']
+    del config['loggers']
+
+    errors = PYTHON_LOGGING_CONFIG_SCHEMA.errors(config)
+    assert len(errors) == 1
+    assert errors[0].code == 'UNKNOWN'
+    assert errors[0].message == 'Logger "root" references handler "console", which is not configured.'
+    assert errors[0].pointer == 'root.handlers.0'
+
+    config = copy.deepcopy(base_test_config)
+    config['incremental'] = True
+    del config['handlers']
+
+    assert PYTHON_LOGGING_CONFIG_SCHEMA.errors(config) == []


### PR DESCRIPTION
- Add standard Python logging config dict schema validation.
- Add support for a `Sequence` type (to support the above).
- Add support for extra validation for all collection (structure) types (to support the above).
- Fix a new bug in autodoc generation (to support the above).
- Update documentation (to support the above).