### PR TITLE
[PATCH] Fix bug in Sphix ext improperly resolving signatures

### DIFF
--- a/conformity/fields/logging.py
+++ b/conformity/fields/logging.py
@@ -10,8 +10,11 @@ from typing import (  # noqa: F401 TODO Python 3
     Hashable as HashableType,
     List as ListType,
     Mapping,
+    Optional,
     Tuple as TupleType,
 )
+
+import six  # noqa: F401 TODO Python 3
 
 from conformity import fields
 from conformity.error import (
@@ -34,7 +37,7 @@ class PythonLogLevel(fields.Constant):
     documentation.
     """
 
-    def __init__(self, description=None):
+    def __init__(self, description=None):  # type: (Optional[six.text_type]) -> None
         """
         Constructs a `PythonLogLevel` field.
 

--- a/tests/sphinx_ext/utils.py
+++ b/tests/sphinx_ext/utils.py
@@ -1,0 +1,14 @@
+from __future__ import (
+    absolute_import,
+    unicode_literals,
+)
+
+import functools
+
+
+def decorated(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+
+    return wrapper


### PR DESCRIPTION
If a method was decoratod, the annotations found for it by the Sphix extension did not match, and often resulted in errors. This fixes that bug.