### PR TITLE
[PATCH] EB-124910 Adding pointer to extra key error dictionary field

### DIFF
--- a/conformity/fields/structures.py
+++ b/conformity/fields/structures.py
@@ -301,13 +301,12 @@ class Dictionary(Base):
         # Check for extra keys
         extra_keys = set(value.keys()) - set(self.contents.keys())
         if extra_keys and not self.allow_extra_keys:
-            result.append(
-                Error(
-                    'Extra keys present: {}'.format(', '.join(six.text_type(key) for key in sorted(extra_keys))),
+            for extra_key in sorted(extra_keys):
+                result.append(Error(
+                    'Extra key present: {}'.format(six.text_type(extra_key)),
                     code=ERROR_CODE_UNKNOWN,
-                    pointer=six.text_type(sorted(extra_keys)[0]),
-                ),
-            )
+                    pointer=six.text_type(extra_key),
+                ))
 
         if not result and self.additional_validator:
             return self.additional_validator.errors(value)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -139,11 +139,8 @@ class FieldTests(unittest.TestCase):
             sorted([
                 Error('Not an integer', pointer='child_ids.2'),
                 Error('Missing key: address', code=ERROR_CODE_MISSING, pointer='address'),
-                Error(
-                    'Extra keys present: another_bad, unsolicited_item',
-                    code=ERROR_CODE_UNKNOWN,
-                    pointer='another_bad',
-                ),
+                Error('Extra key present: another_bad', code=ERROR_CODE_UNKNOWN, pointer='another_bad'),
+                Error('Extra key present: unsolicited_item', code=ERROR_CODE_UNKNOWN, pointer='unsolicited_item'),
                 Error('Not a set or frozenset', pointer='unique_things'),
             ]),
         )

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -368,7 +368,7 @@ class TestSettingsTwo(object):
                 },
             })
 
-        assert '- inner_qux.not_defined: Extra keys present: not_defined' in error_context.value.args[0]
+        assert '- inner_qux.not_defined: Extra key present: not_defined' in error_context.value.args[0]
 
         with pytest.raises(Settings.ImproperlyConfigured) as error_context:
             SettingsTwo({


### PR DESCRIPTION
Adding **pointer** to extra key error dictionary field.
This will prevent not clear messages, for instance at the API level.

### Needed Request Schema

    {
        "performer": {
            "artist_id": 2
        }
    }

### Realized request

    {
        "performer": {
            "artist_id": 2,
            "not_known_field": 12
        }
    }

### Response

    {
        "status_code": 400,
        "error_description": "There are errors with your arguments: performer - UNKNOWN",
        "error": "ARGUMENTS_ERROR"
    }

### Expected response

    {
        "status_code": 400,
        "error_description": "There are errors with your arguments: performer.not_known_field - UNKNOWN",
        "error": "ARGUMENTS_ERROR"
    }
