### PR TITLE
[PATCH] [SPHINX] Soft fail getting annotations when source not found

### DIFF
--- a/conformity/sphinx_ext/autodoc.py
+++ b/conformity/sphinx_ext/autodoc.py
@@ -174,10 +174,17 @@ def get_annotations(
     if arg_spec.annotations:
         return arg_spec.annotations
 
+    try:
+        source_lines = inspect.getsourcelines(function_object)[0]
+    except OSError as e:
+        if 'could not get source code' in e.args[0]:
+            return {}
+        raise
+
     function_started = args_started = args_finished = False
     full_type_comment: Optional[str] = None
     annotations: Dict[str, Any] = {}
-    for line in inspect.getsourcelines(function_object)[0]:
+    for line in source_lines:
         line = line.strip()
         if not line:
             continue
@@ -403,6 +410,7 @@ def _get_settings_schema_documentation(settings_class_object: Type[Settings]) ->
     for k, v in sorted(settings_class_object.schema.items(), key=lambda i: i[0]):
         lines.extend('- ``{}`` - {}'.format(k, _pretty_introspect(v)).split('\n'))
 
+    lines.append('')
     lines.append('**Default Values**')
     lines.append('')
     lines.append(

--- a/conformity/sphinx_ext/linkcode.py
+++ b/conformity/sphinx_ext/linkcode.py
@@ -98,7 +98,7 @@ def create_linkcode_resolve(
         except (TypeError, OSError):
             try:
                 source, start_line = inspect.getsourcelines(obj)
-            except TypeError:
+            except (TypeError, OSError):
                 source, start_line = [], 0
         if source and start_line:
             suffix = f'#L{start_line}-L{start_line + len(source) - 1}'

--- a/tests/sphinx_ext/test_autodoc.py
+++ b/tests/sphinx_ext/test_autodoc.py
@@ -452,13 +452,14 @@ def test_autodoc_process_docstring_settings_class():
     assert lines[50] == '  **values**'
     assert lines[51] == '    ``boolean``: *(no description)*'
     assert lines[52] == ''
-    assert lines[53] == '**Default Values**'
-    assert lines[54] == ''
-    assert lines[55] == 'Keys present in the dict below can be omitted from compliant settings dicts, in which case ' \
+    assert lines[53] == ''
+    assert lines[54] == '**Default Values**'
+    assert lines[55] == ''
+    assert lines[56] == 'Keys present in the dict below can be omitted from compliant settings dicts, in which case ' \
                         'the values below will apply as the default values.'
-    assert lines[56] == ''
-    assert lines[57] == '.. code-block:: json'
-    assert lines[58] == ''
+    assert lines[57] == ''
+    assert lines[58] == '.. code-block:: json'
+    assert lines[59] == ''
 
     assert json.loads('\n'.join(lines[59:]).strip()) == SettingsToTest.defaults
 


### PR DESCRIPTION
In the Sphinx Autodoc and LinkCode extensions, if `inspect` cannot get the source lines for a member, that by extension means the member doesn't have annotations, so there's no reason to fail hard in `get_annotations`, and there's also no reason to fail hard in generating a link to the source code.

Also, add missing newline in settings schema documentation.