### PR TITLE
[PATCH] Fix Constant field when receiving unhashable values

### DIFF
--- a/conformity/fields/basic.py
+++ b/conformity/fields/basic.py
@@ -34,6 +34,12 @@ from conformity.utils import (
 )
 
 
+try:
+    from collections.abc import Hashable as HashableClass
+except ImportError:
+    from collections import Hashable as HashableClass
+
+
 # Blah ... until recursive types are supported, this is not strict enough: https://github.com/python/mypy/issues/731
 Introspection = Dict[
     six.text_type,
@@ -99,7 +105,7 @@ class Constant(Base):
             self._error_message = 'Value is not one of: {}'.format(', '.join(sorted(_repr(v) for v in self.values)))
 
     def errors(self, value):  # type: (AnyType) -> ListType[Error]
-        if value not in self.values:
+        if not isinstance(value, HashableClass) or value not in self.values:
             return [Error(self._error_message, code=ERROR_CODE_UNKNOWN)]
         return []
 

--- a/conformity/fields/basic.py
+++ b/conformity/fields/basic.py
@@ -34,12 +34,6 @@ from conformity.utils import (
 )
 
 
-try:
-    from collections.abc import Hashable as HashableClass
-except ImportError:
-    from collections import Hashable as HashableClass
-
-
 # Blah ... until recursive types are supported, this is not strict enough: https://github.com/python/mypy/issues/731
 Introspection = Dict[
     six.text_type,
@@ -105,7 +99,13 @@ class Constant(Base):
             self._error_message = 'Value is not one of: {}'.format(', '.join(sorted(_repr(v) for v in self.values)))
 
     def errors(self, value):  # type: (AnyType) -> ListType[Error]
-        if not isinstance(value, HashableClass) or value not in self.values:
+        try:
+            is_valid = value in self.values
+        except TypeError:
+            # Unhashable values can't be used for membership checks.
+            is_valid = False
+
+        if not is_valid:
             return [Error(self._error_message, code=ERROR_CODE_UNKNOWN)]
         return []
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -769,6 +769,10 @@ class FieldTests(unittest.TestCase):
             schema.errors(360000),
             [Error('Value is not one of: 36, 42, 81, 9231', code=ERROR_CODE_UNKNOWN)],
         )
+        self.assertEqual(
+            schema.errors([42]),
+            [Error('Value is not one of: 36, 42, 81, 9231', code=ERROR_CODE_UNKNOWN)],
+        )
 
         with pytest.raises(TypeError):
             Constant(42, 36, 81, 9231, description='foo', unsupported='bar')


### PR DESCRIPTION
Currently, the `Constant` field raises an error when receiving and
trying to validate an unhashable value.

The reason is that `if value not in self.values:` expects a hashable
value, and fails with an error like `TypeError: unhashable type: 'list'`
otherwise.