### PR TITLE
[MINOR] Add currency code field

### DIFF
--- a/conformity/fields/currency.py
+++ b/conformity/fields/currency.py
@@ -347,17 +347,12 @@ class CurrencyCodeField(Constant):
 
     def errors(self, value):
         if not isinstance(value, six.text_type):
-            return [Error("Not a unicode string")]
+            return [Error('Not a unicode string')]
 
-        if value not in self.values:
-            return [Error(
-                "Not a valid currency code",
-                code=ERROR_CODE_INVALID,
-                pointer="value",
-            )]
+        return super(CurrencyCodeField, self).errors(value)
 
     def introspect(self):
         return strip_none({
-            "type": self.introspect_type,
-            "valid_currency_codes": self.values,
+            'type': self.introspect_type,
+            'valid_currency_codes': self.values,
         })

--- a/conformity/fields/currency.py
+++ b/conformity/fields/currency.py
@@ -25,8 +25,8 @@ from conformity.error import (
 from conformity.fields.basic import (
     Base,
     Constant,
-    Introspection,
     Integer,
+    Introspection,
     UnicodeString,
 )
 from conformity.fields.structures import Dictionary

--- a/conformity/fields/currency.py
+++ b/conformity/fields/currency.py
@@ -4,14 +4,6 @@ from __future__ import (
 )
 
 import re
-from typing import (
-    AbstractSet,
-    Any as AnyType,
-    Iterable,
-    List as ListType,
-    Optional,
-    Tuple as TupleType,
-)
 import warnings
 
 import attr
@@ -26,7 +18,6 @@ from conformity.fields.basic import (
     Base,
     Constant,
     Integer,
-    Introspection,
     UnicodeString,
 )
 from conformity.fields.structures import Dictionary
@@ -348,6 +339,13 @@ class CurrencyCodeField(Constant):
     def errors(self, value):
         if not isinstance(value, six.text_type):
             return [Error('Not a unicode string')]
+
+        if value not in self.values:
+            return [Error(
+                'Not a valid currency code',
+                code=ERROR_CODE_INVALID,
+                pointer='value',
+            )]
 
         return super(CurrencyCodeField, self).errors(value)
 

--- a/conformity/fields/currency.py
+++ b/conformity/fields/currency.py
@@ -349,12 +349,7 @@ class CurrencyCodeField(Constant):
         if not isinstance(value, six.text_type):
             return [Error('Not a unicode string')]
 
-        if value not in self.values:
-            return [Error(
-                'Not a valid currency code',
-                code=ERROR_CODE_INVALID,
-                pointer='value',
-            )]
+        return super(CurrencyCodeField, self).errors(value)
 
     def introspect(self):
         return strip_none({

--- a/conformity/fields/currency.py
+++ b/conformity/fields/currency.py
@@ -356,8 +356,6 @@ class CurrencyCodeField(Constant):
                 pointer='value',
             )]
 
-        return super(CurrencyCodeField, self).errors(value)
-
     def introspect(self):
         return strip_none({
             'type': self.introspect_type,

--- a/conformity/fields/currency.py
+++ b/conformity/fields/currency.py
@@ -4,6 +4,14 @@ from __future__ import (
 )
 
 import re
+from typing import (
+    AbstractSet,
+    Any as AnyType,
+    Iterable,
+    List as ListType,
+    Optional,
+    Tuple as TupleType,
+)
 import warnings
 
 import attr
@@ -17,6 +25,7 @@ from conformity.error import (
 from conformity.fields.basic import (
     Base,
     Constant,
+    Introspection,
     Integer,
     UnicodeString,
 )

--- a/conformity/fields/currency.py
+++ b/conformity/fields/currency.py
@@ -334,7 +334,7 @@ class CurrencyCodeField(Constant):
     An enum field for restricting values to valid currency codes. Permits only current currencies
     and uses currint library.
     """
-    introspect_type = "currency_code_field"
+    introspect_type = 'currency_code_field'
 
     def __init__(self, code_filter=lambda x: True, **kwargs):
         """
@@ -350,9 +350,3 @@ class CurrencyCodeField(Constant):
             return [Error('Not a unicode string')]
 
         return super(CurrencyCodeField, self).errors(value)
-
-    def introspect(self):
-        return strip_none({
-            'type': self.introspect_type,
-            'valid_currency_codes': self.values,
-        })

--- a/conformity/fields/currency.py
+++ b/conformity/fields/currency.py
@@ -327,3 +327,37 @@ class AmountResponseDictionary(Dictionary):
             allow_extra_keys=False,
             description=description,
         )
+
+
+class CurrencyCodeField(Constant):
+    """
+        An enum field for restricting values to valid currency codes. Permits only current currencies
+        and uses currint library.
+    """
+    introspect_type = "currency_code_field"
+
+    def __init__(self, code_filter=lambda x: True, **kwargs):
+        """
+        :param code_filter: If specified, will be called to further filter the available currency codes
+        :type code_filter: lambda x: bool
+        """
+
+        valid_currency_codes = (code for code in DEFAULT_CURRENCY_CODES if code_filter(code))
+        super(CurrencyCodeField, self).__init__(*valid_currency_codes, **kwargs)
+
+    def errors(self, value):
+        if not isinstance(value, six.text_type):
+            return [Error("Not a unicode string")]
+
+        if value not in self.values:
+            return [Error(
+                "Not a valid currency code",
+                code=ERROR_CODE_INVALID,
+                pointer="value",
+            )]
+
+    def introspect(self):
+        return strip_none({
+            "type": self.introspect_type,
+            "valid_currency_codes": self.values,
+        })

--- a/conformity/fields/currency.py
+++ b/conformity/fields/currency.py
@@ -331,8 +331,8 @@ class AmountResponseDictionary(Dictionary):
 
 class CurrencyCodeField(Constant):
     """
-        An enum field for restricting values to valid currency codes. Permits only current currencies
-        and uses currint library.
+    An enum field for restricting values to valid currency codes. Permits only current currencies
+    and uses currint library.
     """
     introspect_type = "currency_code_field"
 

--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -335,6 +335,12 @@ There are four other fields that make use of `Currint`_ types if you specify the
   not extend ``UnicodeString``) that enforces the value meet the currency format ``'CUR,1234'`` or ``'CUR:1234'``, and,
   like ``Amount``, supports ``valid_currencies``, ``gt``, ``gte``, ``lt``, and ``lte`` optional arguments.
 
+- `currency.CurrencyCodeField <reference.html#conformity.fields.currency.CurrencyCodeField>`_: is a special extension of
+``Constant`` that ensures the value is a unicode string that enforces the value meet the currency format as ``'USD'`. It has one
+argument, ``code_filter``, which if specified must be a ``typing.Callable[[typing.AnyStr], bool]``. The filter will be
+passed a currency code and should return ``True`` if that currency code is allowed and ``False`` if it is not allowed.
+This is an eager filter that will filter the allowed currency codes when the instance is constructed instead of waiting
+until validation time.
 
 Advanced Fields
 ---------------

--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -336,7 +336,7 @@ There are four other fields that make use of `Currint`_ types if you specify the
   like ``Amount``, supports ``valid_currencies``, ``gt``, ``gte``, ``lt``, and ``lte`` optional arguments.
 
 - `currency.CurrencyCodeField <reference.html#conformity.fields.currency.CurrencyCodeField>`_: is a special extension of
-``Constant`` that ensures the value is a Unicode string that enforces the value meets the currency format as ``'USD'`. It has one
+``Constant`` that ensures the value is a Unicode string that enforces the value meets the currency format as ``'USD'``. It has one
 argument, ``code_filter``, which if specified must be a ``typing.Callable[[typing.AnyStr], bool]``. The filter will be
 passed a currency code and should return ``True`` if that currency code is allowed and ``False`` if it is not allowed.
 This is an eager filter that will filter the allowed currency codes when the instance is constructed instead of waiting

--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -331,12 +331,12 @@ There are four other fields that make use of `Currint`_ types if you specify the
           "major_value": "12.00",
           "display": "12.00 USD",
       }
-- `currency.AmountString <reference.html#conformity.fields.currency.AmountString>`_: A unicode string field (which does
-  not extend ``UnicodeString``) that enforces the value meet the currency format ``'CUR,1234'`` or ``'CUR:1234'``, and,
+- `currency.AmountString <reference.html#conformity.fields.currency.AmountString>`_: A Unicode string field (which does
+  not extend ``UnicodeString``) that enforces the value meets the currency format ``'CUR,1234'`` or ``'CUR:1234'``, and,
   like ``Amount``, supports ``valid_currencies``, ``gt``, ``gte``, ``lt``, and ``lte`` optional arguments.
 
 - `currency.CurrencyCodeField <reference.html#conformity.fields.currency.CurrencyCodeField>`_: is a special extension of
-``Constant`` that ensures the value is a unicode string that enforces the value meet the currency format as ``'USD'`. It has one
+``Constant`` that ensures the value is a Unicode string that enforces the value meets the currency format as ``'USD'`. It has one
 argument, ``code_filter``, which if specified must be a ``typing.Callable[[typing.AnyStr], bool]``. The filter will be
 passed a currency code and should return ``True`` if that currency code is allowed and ``False`` if it is not allowed.
 This is an eager filter that will filter the allowed currency codes when the instance is constructed instead of waiting

--- a/tests/test_fields_currency.py
+++ b/tests/test_fields_currency.py
@@ -494,4 +494,4 @@ class CurrencyCodeTest(unittest.TestCase):
 
     def test_introspect(self):
         introspection = self.field.introspect()
-        self.assertEqual("currency_code_field", introspection["type"])
+        self.assertEqual('currency_code_field', introspection['type'])

--- a/tests/test_fields_currency.py
+++ b/tests/test_fields_currency.py
@@ -458,3 +458,44 @@ class TestAmountDictionariesAndStrings(object):
             'AmountDictionary is deprecated and will be removed in Conformity 2.0. '
             'Use AmountRequestDictionary, instead.'
         ) in str(w[-1].message)
+
+
+class CurrencyCodeTest(unittest.TestCase):
+    """
+        Tests the CurrencyCodeField field
+    """
+
+    def setUp(self):
+        self.currency = 'USD'
+        self.field = currency_fields.CurrencyCodeField()
+
+    def test_valid(self):
+        self.assertEqual(self.field.errors(self.currency), None)
+
+    def test_invalid_currency_code(self):
+        currency = 'US'
+        errors = self.field.errors(currency)
+        self.assertEqual(len(errors), 1)
+        error = errors[0]
+        self.assertEqual(
+            error.code,
+            ERROR_CODE_INVALID,
+        )
+        self.assertEqual(
+            error.message,
+            'Not a valid currency code',
+        )
+
+    def test_not_unicode_string(self):
+        currency = b'USD'
+        errors = self.field.errors(currency)
+        self.assertEqual(len(errors), 1)
+        error = errors[0]
+        self.assertEqual(
+            error.message,
+            'Not a unicode string',
+        )
+
+    def test_introspect(self):
+        introspection = self.field.introspect()
+        self.assertEqual("currency_code_field", introspection["type"])

--- a/tests/test_fields_currency.py
+++ b/tests/test_fields_currency.py
@@ -479,11 +479,7 @@ class CurrencyCodeTest(unittest.TestCase):
         error = errors[0]
         self.assertEqual(
             error.code,
-            ERROR_CODE_INVALID,
-        )
-        self.assertEqual(
-            error.message,
-            'Not a valid currency code',
+            ERROR_CODE_UNKNOWN,
         )
 
     def test_not_unicode_string(self):

--- a/tests/test_fields_currency.py
+++ b/tests/test_fields_currency.py
@@ -462,7 +462,7 @@ class TestAmountDictionariesAndStrings(object):
 
 class CurrencyCodeTest(unittest.TestCase):
     """
-        Tests the CurrencyCodeField field
+    Tests the CurrencyCodeField field
     """
 
     def setUp(self):

--- a/tests/test_fields_currency.py
+++ b/tests/test_fields_currency.py
@@ -470,7 +470,7 @@ class CurrencyCodeTest(unittest.TestCase):
         self.field = currency_fields.CurrencyCodeField()
 
     def test_valid(self):
-        self.assertEqual(self.field.errors(self.currency), None)
+        self.assertEqual(self.field.errors(self.currency), [])
 
     def test_invalid_currency_code(self):
         currency = 'US'


### PR DESCRIPTION
Add a new field to validate currency codes. This field is a special extension of
Constant that ensures the value is a Unicode string that enforces the value meets the currency format as `'USD'`. It has one
argument, `code_filter`, which if specified must be a `typing.Callable[[typing.AnyStr], bool]`. 