### PR TITLE
[PATCH] Differentiate import errors from other validation errors

### DIFF
--- a/conformity/fields/meta.py
+++ b/conformity/fields/meta.py
@@ -198,9 +198,9 @@ class PythonPath(Base):
         except ValueError:
             return [Error('Value "{}" is not a valid Python import path'.format(value))]
         except ImportError as e:
-            return [Error(six.text_type(e.args[0]))]
+            return [Error('ImportError: {}'.format(six.text_type(e.args[0])))]
         except AttributeError as e:
-            return [Error(six.text_type(e.args[0]))]
+            return [Error('AttributeError: {}'.format(six.text_type(e.args[0])))]
 
         if self.value_schema:
             return self.value_schema.errors(thing)

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,7 @@ ignore_missing_imports = True
 test=pytest
 
 [tool:pytest]
+junit_family = xunit2
 addopts = -s --junitxml=pytests.xml --cov-fail-under=85 --cov-branch --cov-report=term-missing --cov=conformity
 filterwarnings =
     ignore:.*:DeprecationWarning:jinja2.utils

--- a/tests/test_fields_meta.py
+++ b/tests/test_fields_meta.py
@@ -369,12 +369,12 @@ class MetaFieldTests(unittest.TestCase):
         assert schema.errors(b'Nope nope nope') == [Error('Not a unicode string')]
         assert schema.errors('Nope nope nope') == [Error('Value "Nope nope nope" is not a valid Python import path')]
         assert schema.errors('foo.bar:Hello') == [
-            Error('No module named foo.bar' if six.PY2 else "No module named 'foo'")
+            Error('ImportError: No module named foo.bar' if six.PY2 else "ImportError: No module named 'foo'")
         ]
         assert schema.errors('conformity.fields:NotARealField') == [
             Error(
-                "'module' object has no attribute 'NotARealField'" if six.PY2 else
-                "module 'conformity.fields' has no attribute 'NotARealField'"
+                "AttributeError: 'module' object has no attribute 'NotARealField'" if six.PY2 else
+                "AttributeError: module 'conformity.fields' has no attribute 'NotARealField'"
             )
         ]
         assert schema.errors('conformity.fields:UnicodeString') == []
@@ -501,7 +501,7 @@ class TestClassConfigurationSchema(object):
             Error('Missing key (and no default specified): path', code='MISSING', pointer='path'),
         ]
         assert schema.errors({'path': 'foo.bar:Hello'}) == [Error(
-            'No module named foo.bar' if six.PY2 else "No module named 'foo'",
+            'ImportError: No module named foo.bar' if six.PY2 else "ImportError: No module named 'foo'",
             pointer='path',
         )]
         assert schema.errors({'path': 'tests.test_fields_meta.Foo'}) == [Error(


### PR DESCRIPTION
The issue eventbrite/pymetrics#9 is caused by the fact that Conformity wraps `ImportError`s that occur during validation. This tiny tweak makes it possible for PyMetrics to easily detect such errors and include them in its circular-import protection code.