### PR TITLE
Fix for Dockerfile smell DL3015

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 FROM ubuntu:16.04
 
 RUN apt-get update && \
-    apt-get install -y \
+    apt-get install --no-install-recommends -y \
         git \
         pkg-config \
         software-properties-common \
         wget
 RUN add-apt-repository ppa:deadsnakes/ppa && \
     apt-get update && \
-    apt-get install -y \
+    apt-get install --no-install-recommends -y \
         python2.7 \
         python2.7-dev \
         python3.4 \


### PR DESCRIPTION
Hi!
The Dockerfile placed at "Dockerfile" contains the best practice violation [DL3015](https://github.com/hadolint/hadolint/wiki/DL3015) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3015 occurs when the apt tool is used to install packages without the "--no-install-recommends" flag. This flag is recommended to be used to avoid installing additional packages not explicitly requested.
In this pull request, we propose a fix for that smell generated by our fixing tool. We have verified that the patch is correct before opening the pull request.
To fix this smell, specifically, the "--no-install-recommends" flag is added to the apt-get install command.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance